### PR TITLE
feat: add progressive profiling form

### DIFF
--- a/src/forms/progressive-profiling-popup/data/constants.js
+++ b/src/forms/progressive-profiling-popup/data/constants.js
@@ -1,0 +1,89 @@
+const optionalFieldData = {
+  subject: {
+    options: [],
+  },
+  levelOfEducation: {
+    options: [
+      {
+        label: 'none',
+      },
+      {
+        label: 'jhs',
+      },
+      {
+        label: 'hs',
+      },
+      {
+        label: 'a',
+      },
+      {
+        label: 'b',
+      },
+      {
+        label: 'm',
+      },
+      {
+        label: 'p',
+      },
+      {
+        label: 'other',
+      },
+    ],
+  },
+  workExperience: {
+    options: [
+      {
+        label: '0yrs',
+      },
+      {
+        label: '1-5yrs',
+      },
+      {
+        label: '6-10yrs',
+      },
+      {
+        label: '11-15yrs',
+      },
+      {
+        label: '16-20yrs',
+      },
+      {
+        label: '20+yrs',
+      },
+    ],
+  },
+  learningType: {
+    options: [
+      {
+        label: 'Courses',
+      },
+      {
+        label: 'Boot Camps',
+      },
+      {
+        label: 'Degrees',
+      },
+      {
+        label: 'Executive Education',
+      },
+      {
+        label: 'unsure',
+      },
+    ],
+  },
+  gender: {
+    options: [
+      {
+        label: 'm',
+      },
+      {
+        label: 'f',
+      },
+      {
+        label: 'o',
+      },
+    ],
+  },
+};
+
+export default optionalFieldData;

--- a/src/forms/progressive-profiling-popup/index.jsx
+++ b/src/forms/progressive-profiling-popup/index.jsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+
+import { getCountryList, getLocale, useIntl } from '@edx/frontend-platform/i18n';
+import {
+  Button, Container, Form, Icon,
+} from '@openedx/paragon';
+import { Language } from '@openedx/paragon/icons';
+
+import './index.scss';
+import optionalFieldData from './data/constants';
+import messages from './messages';
+import BaseContainer from '../../base-container';
+
+/**
+ * Progressive profiling form component. This component holds the logic to render optional demographic
+ * form fields and infor users about the auto-generated country field.
+ *
+ * @returns {JSX.Element} Progressive profiling form rendered inside BaseContainer component.
+ */
+const ProgressiveProfilingForm = () => {
+  const { formatMessage } = useIntl();
+  const countryList = useMemo(() => getCountryList(getLocale()), []);
+
+  const getFieldOptions = (fieldName, fieldData) => fieldData.options.map(option => (
+    <Form.AutosuggestOption id={option.name}>
+      {formatMessage(messages[`${fieldName}.option.${option.label}`])}
+    </Form.AutosuggestOption>
+  ));
+
+  const getCountryFieldOptions = () => countryList.map((country) => (
+    <Form.AutosuggestOption key={country.code}>
+      {country.name}
+    </Form.AutosuggestOption>
+  ));
+
+  return (
+    <BaseContainer open setOpen={() => {}}>
+      <Container size="lg" className="authn__popup-container overflow-auto">
+        <h1 className="display-1 font-italic text-center mb-4">
+          {formatMessage(messages.progressiveProfilingFormHeading)}
+        </h1>
+        <p className="text-center">
+          {formatMessage(messages.progressiveProfilingCompletionSkipMessage)}
+        </p>
+        <hr className="heading-separator mb-3 mt-3" />
+        <Form id="progressive-profiling" name="progressive-profiling">
+          <h3 className="mb-2.5 mt-2">
+            {formatMessage(messages.progressiveProfilingCountryFieldTitle)}
+          </h3>
+          <p className="x-small">
+            {formatMessage(messages.progressiveProfilingCountryFieldInfoMessage)}
+          </p>
+          <Form.Group controlId="country" className="mb-4.5">
+            <Form.Autosuggest
+              name="country"
+              placeholder={formatMessage(messages.useProfileCountryFieldUndetected)}
+              leadingElement={<Icon src={Language} />}
+            >
+              {getCountryFieldOptions()}
+            </Form.Autosuggest>
+            <Form.Control.Feedback>
+              {formatMessage(messages.progressiveProfilingCountryFieldHelpText)}
+            </Form.Control.Feedback>
+          </Form.Group>
+          <h3 className="mb-2.5">
+            {formatMessage(messages.progressiveProfilingDataCollectionTitle)}
+          </h3>
+          <Form.Group controlId="subject" className="mb-4.5">
+            <Form.Label>
+              {formatMessage(messages.progressiveProfilingSubjectFieldLabel)}
+            </Form.Label>
+            <Form.Autosuggest
+              name="subject"
+              placeholder={formatMessage(messages.progressiveProfilingSubjectFieldPlaceholder)}
+            >
+              {getFieldOptions('subject', optionalFieldData.subject)}
+            </Form.Autosuggest>
+          </Form.Group>
+          <Form.Group controlId="level-of-education" className="mb-4.5">
+            <Form.Label>
+              {formatMessage(messages.progressiveProfilingLevelOfEducationFieldLabel)}
+            </Form.Label>
+            <Form.Autosuggest
+              name="level-of-education"
+              placeholder={formatMessage(messages.progressiveProfilingLevelOfEducationFieldPlaceholder)}
+            >
+              {getFieldOptions('levelOfEducation', optionalFieldData.levelOfEducation)}
+            </Form.Autosuggest>
+          </Form.Group>
+          <Form.Group controlId="work-experience" className="mb-4.5">
+            <Form.Label>
+              {formatMessage(messages.progressiveProfilingWorkExperienceFieldLabel)}
+            </Form.Label>
+            <Form.Autosuggest
+              name="work-experience"
+              placeholder={formatMessage(messages.progressiveProfilingWorkExperienceFieldPlaceholder)}
+            >
+              {getFieldOptions('workExperience', optionalFieldData.workExperience)}
+            </Form.Autosuggest>
+          </Form.Group>
+          <Form.Group controlId="learning-type" className="mb-4.5">
+            <Form.Label>
+              {formatMessage(messages.progressiveProfilingLearningTypeFieldLabel)}
+            </Form.Label>
+            <Form.Autosuggest
+              name="learning-type"
+              placeholder={formatMessage(messages.progressiveProfilingLearningTypeFieldPlaceholder)}
+            >
+              {getFieldOptions('learningType', optionalFieldData.learningType)}
+            </Form.Autosuggest>
+          </Form.Group>
+          <Form.Group controlId="gender" className="mb-4.5">
+            <Form.Label>
+              {formatMessage(messages.progressiveProfilingGenderFieldLabel)}
+            </Form.Label>
+            <Form.Autosuggest
+              name="gender"
+              placeholder={formatMessage(messages.progressiveProfilingGenderFieldPlaceholder)}
+            >
+              {getFieldOptions('gender', optionalFieldData.gender)}
+            </Form.Autosuggest>
+          </Form.Group>
+          <div className="d-flex my-4 justify-content-end progressive-profiling__cta-btn-container">
+            <Button
+              id="skip-optional-fields"
+              name="skip-optional-fields"
+              type="submit"
+              variant="outline-dark"
+              onClick={() => {}}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {formatMessage(messages.progressiveProfilingSkipForNowButtonText)}
+            </Button>
+            <Button
+              id="submit-optional-fields"
+              name="submit-optional-fields"
+              type="submit"
+              onClick={() => {}}
+              onMouseDown={(e) => e.preventDefault()}
+            >
+              {formatMessage(messages.progressiveProfilingSubmitButtonText)}
+            </Button>
+          </div>
+        </Form>
+      </Container>
+    </BaseContainer>
+  );
+};
+
+export default ProgressiveProfilingForm;

--- a/src/forms/progressive-profiling-popup/index.scss
+++ b/src/forms/progressive-profiling-popup/index.scss
@@ -1,0 +1,3 @@
+.progressive-profiling__cta-btn-container {
+  gap: 12px;
+}

--- a/src/forms/progressive-profiling-popup/messages.js
+++ b/src/forms/progressive-profiling-popup/messages.js
@@ -1,0 +1,220 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  progressiveProfilingFormHeading: {
+    id: 'progressive.profiling.form.heading',
+    defaultMessage: 'Fill out your profile',
+    description: 'Heading for the form that appears after a user registers with edX',
+  },
+  progressiveProfilingCompletionSkipMessage: {
+    id: 'progressive.profiling.completion.skip.message',
+    defaultMessage: 'If you skip now, you can complete your profile under "Account settings" at any time.',
+    description: 'Message that appears on the user profile completion form',
+  },
+  progressiveProfilingCountryFieldTitle: {
+    id: 'progressive.profiling.country.field.title',
+    defaultMessage: 'Confirm your country of residence',
+    description: 'Title for the country field',
+  },
+  progressiveProfilingCountryFieldInfoMessage: {
+    id: 'progressive.profiling.country.field.info.message',
+    defaultMessage: 'We have determined your country of residence. If this is incorrect, please edit your country.',
+    description: 'Informative message for the auto-populated country field',
+  },
+  useProfileCountryFieldUndetected: {
+    id: 'progressive.profiling.country.field.undetected',
+    defaultMessage: 'Undetected',
+    description: 'Placeholder text for country field when we are not able to auto-detect the country',
+  },
+  progressiveProfilingCountryFieldHelpText: {
+    id: 'progressive.profiling.country.field.help.text',
+    defaultMessage: 'Your country of residence determines availability of certain courses',
+    description: 'Help text for country field',
+  },
+  progressiveProfilingDataCollectionTitle: {
+    id: 'progressive.profiling.data.collection.title',
+    defaultMessage: 'Personalize your experience',
+    description: 'Title that appears above optional demographic fields',
+  },
+  progressiveProfilingSubjectFieldLabel: {
+    id: 'progressive.profiling.subject.field.label',
+    defaultMessage: 'What field are you interested in?',
+    description: '"Subject" field label',
+  },
+  progressiveProfilingSubjectFieldPlaceholder: {
+    id: 'progressive.profiling.subject.field.placeholder',
+    defaultMessage: 'Select a field',
+    description: '"Subject" field placeholder text',
+  },
+  progressiveProfilingLevelOfEducationFieldLabel: {
+    id: 'progressive.profiling.level.of.education.field.label',
+    defaultMessage: 'What is the highest level of education you have completed?',
+    description: '"Level of Education" field label',
+  },
+  progressiveProfilingLevelOfEducationFieldPlaceholder: {
+    id: 'progressive.profiling.level.of.education.field.placeholder',
+    defaultMessage: 'Select a level',
+    description: '"Level of Education" field placeholder text',
+  },
+  progressiveProfilingWorkExperienceFieldLabel: {
+    id: 'progressive.profiling.work.experience.field.label',
+    defaultMessage: 'How many years of work experience do you have?',
+    description: '"Work Experience" field label',
+  },
+  progressiveProfilingWorkExperienceFieldPlaceholder: {
+    id: 'progressive.profiling.work.experience.field.placeholder',
+    defaultMessage: 'Select an option',
+    description: '"Work Experience" field placeholder text',
+  },
+  progressiveProfilingLearningTypeFieldLabel: {
+    id: 'progressive.profiling.learning.type.field.label',
+    defaultMessage: 'What type of experience are you interested in?',
+    description: '"Learning Type" field label',
+  },
+  progressiveProfilingLearningTypeFieldPlaceholder: {
+    id: 'progressive.profiling.learning.type.field.placeholder',
+    defaultMessage: 'Select a product',
+    description: '"Learning Type" field placeholder text',
+  },
+  progressiveProfilingGenderFieldLabel: {
+    id: 'progressive.profiling.gender.field.label',
+    defaultMessage: 'What is your gender?',
+    description: '"Gender" field label',
+  },
+  progressiveProfilingGenderFieldPlaceholder: {
+    id: 'progressive.profiling.gender.field.placeholder',
+    defaultMessage: 'Select an option',
+    description: '"Gender" field placeholder text',
+  },
+  progressiveProfilingSkipForNowButtonText: {
+    id: 'progressive.profiling.skip.for.now.button.text',
+    defaultMessage: 'Skip for now',
+    description: 'Text that appears on the button that skips the optional profile data form',
+  },
+  progressiveProfilingSubmitButtonText: {
+    id: 'progressive.profiling.submit.button.text',
+    defaultMessage: 'Submit',
+    description: 'Text that appears on the button that submits the optional profile data form',
+  },
+  // Level of Education Options
+  'levelOfEducation.option.none': {
+    id: 'levelOfEducation.option.none',
+    defaultMessage: 'No formal education',
+    description: 'Option for education level field',
+  },
+  'levelOfEducation.option.jhs': {
+    id: 'levelOfEducation.option.jhs',
+    defaultMessage: 'Junior secondary/junior high/middle school',
+    description: 'Option for education level field',
+  },
+  'levelOfEducation.option.hs': {
+    id: 'levelOfEducation.option.hs',
+    defaultMessage: 'Secondary/High School',
+    description: 'Option for education level field',
+  },
+  'levelOfEducation.option.a': {
+    id: 'levelOfEducation.option.a',
+    defaultMessage: 'Associate Degree',
+    description: 'Option for education level field',
+  },
+  'levelOfEducation.option.b': {
+    id: 'levelOfEducation.option.b',
+    defaultMessage: 'Bachelor\'s Degree',
+    description: 'Option for education level field',
+  },
+  'levelOfEducation.option.m': {
+    id: 'levelOfEducation.option.m',
+    defaultMessage: 'Master\'s or professional degree',
+    description: 'Option for education level field',
+  },
+  'levelOfEducation.option.p': {
+    id: 'levelOfEducation.option.p',
+    defaultMessage: 'Doctorate',
+    description: 'Option for education level field',
+  },
+  'levelOfEducation.option.other': {
+    id: 'levelOfEducation.option.other',
+    defaultMessage: 'Other',
+    description: 'Option for education level field',
+  },
+  // Work Experience Options
+  'workExperience.option.0yrs': {
+    id: 'workExperience.option.0yrs',
+    defaultMessage: 'I don’t have any work experience',
+    description: 'Option for work experience field',
+  },
+  'workExperience.option.1-5yrs': {
+    id: 'workExperience.option.1-5yrs',
+    defaultMessage: 'I have 1-5 years of work experience',
+    description: 'Option for work experience field',
+  },
+  'workExperience.option.6-10yrs': {
+    id: 'workExperience.option.6-10yrs',
+    defaultMessage: 'I have 6-10 years of work experience',
+    description: 'Option for work experience field',
+  },
+  'workExperience.option.11-15yrs': {
+    id: 'workExperience.option.11-15yrs',
+    defaultMessage: 'I have 11-15 years of work experience',
+    description: 'Option for work experience field',
+  },
+  'workExperience.option.16-20yrs': {
+    id: 'workExperience.option.16-20yrs',
+    defaultMessage: 'I have 16-20 years of work experience',
+    description: 'Option for work experience field',
+  },
+  'workExperience.option.20+yrs': {
+    id: 'workExperience.option.20+yrs',
+    defaultMessage: 'More than 20 years of work experience',
+    description: 'Option for work experience field',
+  },
+  // Learning Experience Options
+  'learningType.option.Courses': {
+    id: 'learningType.option.Courses',
+    defaultMessage: 'Courses',
+    description: 'Option for learning type dropdown field',
+  },
+  'learningType.option.Programs': {
+    id: 'learningType.option.Programs',
+    defaultMessage: 'Programs',
+    description: 'Option for learning type dropdown field',
+  },
+  'learningType.option.Boot Camps': {
+    id: 'learningType.option.Boot Camps',
+    defaultMessage: 'Boot Camps',
+    description: 'Option for learning type dropdown field',
+  },
+  'learningType.option.Degrees': {
+    id: 'learningType.option.Degree Programs',
+    defaultMessage: 'Degrees',
+    description: 'Option for learning type dropdown field',
+  },
+  'learningType.option.Executive Education': {
+    id: 'learningType.option.Executive Education',
+    defaultMessage: 'Executive Education',
+    description: 'Option for learning type dropdown field',
+  },
+  'learningType.option.unsure': {
+    id: 'learningType.option.Unsure',
+    defaultMessage: 'Unsure',
+    description: 'Option for learning type dropdown field',
+  },
+  // Gender Options
+  'gender.option.m': {
+    id: 'gender.option.m',
+    defaultMessage: 'Male',
+    description: 'Option for gender field',
+  },
+  'gender.option.f': {
+    id: 'gender.option.f',
+    defaultMessage: 'Female',
+    description: 'Option for gender field',
+  },
+  'gender.option.o': {
+    id: 'gender.option.o',
+    defaultMessage: 'Other/Prefer Not to Say',
+    description: 'Option for gender field',
+  },
+});
+
+export default messages;


### PR DESCRIPTION
### Description

- Added progressive profiling form design
- For optional fields dropdown, used the explore MFE (Quiz Match) as reference

#### JIRA

[VAN-1916](https://2u-internal.atlassian.net/browse/VAN-1916)

#### How Has This Been Tested?

Tested the design locally. I have informed UX about the fields not fitting on the screen correctly. We will fix forward it once they provide updated designs. 

#### Screenshots/sandbox (optional):

|Description|UI|
|-------|-----|
|Form with no dropdown option opened|<img width="717" alt="Screenshot 2024-04-29 at 10 28 37 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/40633976/16b520ba-2aaf-49ce-818c-4011b48cf1ec">|
|Country field selected|<img width="717" alt="Screenshot 2024-04-29 at 10 28 43 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/40633976/cadca8bd-248d-400e-80d0-c435cac1d1f1">
|Work experience field select|<img width="717" alt="Screenshot 2024-04-29 at 10 28 54 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/40633976/b005a49b-c6cb-43b5-b801-21dfd5e4dd99">


#### Merge Checklist
* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
