### PR TITLE
feat: add redirect for company and school credentials login

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -8,3 +8,6 @@ export const FAILURE_STATE = 'failure';
 export const INTERNAL_SERVER_ERROR = 'internal-server-error';
 export const FORBIDDEN_REQUEST = 'forbidden-request';
 export const INVALID_FORM = 'invalid-form';
+
+// URL Paths
+export const ENTERPRISE_LOGIN_URL = '/enterprise/login';

--- a/src/forms/login-popup/index.jsx
+++ b/src/forms/login-popup/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { snakeCaseObject } from '@edx/frontend-platform';
+import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button, Container, Form, Hyperlink,
@@ -11,7 +11,7 @@ import { loginUser } from './data/reducers';
 import LoginFailureAlert from './LoginFailureAlert';
 import messages from './messages';
 import { InlineLink, SocialAuthButtons } from '../../common-ui';
-import { INVALID_FORM } from '../../data/constants';
+import { ENTERPRISE_LOGIN_URL, INVALID_FORM } from '../../data/constants';
 import PasswordField from '../fields/password-field';
 import EmailOrUsernameField from '../fields/text-field';
 
@@ -139,7 +139,7 @@ const LoginForm = () => {
           linkText={formatMessage(messages.loginFormRegistrationLink)}
         />
         <InlineLink
-          destination="#"
+          destination={getConfig().LMS_BASE_URL + ENTERPRISE_LOGIN_URL}
           linkHelpText={formatMessage(messages.loginFormSchoolAndOrganizationHelpText)}
           linkText={formatMessage(messages.loginFormSchoolAndOrganizationLink)}
         />

--- a/src/forms/login-popup/tests/LoginPopup.test.jsx
+++ b/src/forms/login-popup/tests/LoginPopup.test.jsx
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { fireEvent, render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
@@ -38,7 +39,7 @@ describe('LoginForm Test', () => {
 
   // ******** test login form submission ********
 
-  it('should submit form for valid input', () => {
+  it('should submit form for valid input', async () => {
     store.dispatch = jest.fn(store.dispatch);
 
     const { container } = render(reduxWrapper(<IntlLoginForm />));
@@ -47,10 +48,25 @@ describe('LoginForm Test', () => {
     const passwordInput = container.querySelector('#password');
     const loginButton = container.querySelector('#login-user');
 
-    fireEvent.change(usernameInput, { target: { value: 'test', name: 'emailOrUsername' } });
-    fireEvent.change(passwordInput, { target: { value: 'test-password', name: 'password' } });
+    await act(async () => {
+      fireEvent.change(usernameInput, { target: { value: 'test', name: 'emailOrUsername' } });
+      fireEvent.change(passwordInput, { target: { value: 'test-password', name: 'password' } });
+    });
     fireEvent.click(loginButton);
 
     expect(store.dispatch).toHaveBeenCalledWith(loginUser({ email_or_username: 'test', password: 'test-password' }));
+  });
+
+  // ******** test login form elements ********
+  it('should show company and school credentials link', async () => {
+    const { getByText } = render(reduxWrapper(<IntlLoginForm />));
+    const schoolAndCompanyLabel = getByText(
+      'Have an account through school or organization?',
+    );
+    const schoolAndCompanyLink = getByText(
+      'Sign in with your credentials',
+    );
+    expect(schoolAndCompanyLabel).toBeTruthy();
+    expect(schoolAndCompanyLink).toBeTruthy();
   });
 });

--- a/src/forms/registration-popup/index.jsx
+++ b/src/forms/registration-popup/index.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 
-import { snakeCaseObject } from '@edx/frontend-platform';
+import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Button, Container, Form, Icon, IconButton, Stepper,
@@ -12,6 +12,7 @@ import { NUM_OF_STEPS, STEP1, STEP2 } from './data/constants';
 import { registerUser } from './data/reducers';
 import messages from './messages';
 import { InlineLink, SocialAuthButtons } from '../../common-ui';
+import { ENTERPRISE_LOGIN_URL } from '../../data/constants';
 import './index.scss';
 import EmailField from '../fields/email-field';
 import MarketingEmailOptInCheckbox from '../fields/marketing-email-opt-out-field';
@@ -173,7 +174,7 @@ const RegistrationForm = () => {
             linkText={formatMessage(messages.registrationFormSignInLink)}
           />
           <InlineLink
-            destination="#"
+            destination={getConfig().LMS_BASE_URL + ENTERPRISE_LOGIN_URL}
             linkHelpText={formatMessage(messages.registrationFormSchoolOrOrganizationLink)}
             linkText={formatMessage(messages.registrationFormSignInWithCredentialsLink)}
           />

--- a/src/forms/registration-popup/tests/RegistrationPopup.test.jsx
+++ b/src/forms/registration-popup/tests/RegistrationPopup.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
+
+import RegistrationForm from '../index';
+
+const IntlRegistrationForm = injectIntl(RegistrationForm);
+const mockStore = configureStore();
+
+describe('RegistrationForm Test', () => {
+  let store = {};
+
+  const reduxWrapper = children => (
+    <IntlProvider locale="en">
+      <MemoryRouter>
+        <Provider store={store}>{children}</Provider>
+      </MemoryRouter>
+    </IntlProvider>
+  );
+
+  beforeEach(() => {
+    store = mockStore({});
+  });
+
+  // ******** test registration form elements ********
+  it('should show company and school credentials link', async () => {
+    const { getByText } = render(reduxWrapper(<IntlRegistrationForm />));
+    const schoolAndCompanyLabel = getByText(
+      'Have an account through school or organization?',
+    );
+    const schoolAndCompanyLink = getByText(
+      'Sign in with your credentials',
+    );
+    expect(schoolAndCompanyLabel).toBeTruthy();
+    expect(schoolAndCompanyLink).toBeTruthy();
+  });
+});


### PR DESCRIPTION
### Description

A simple PR that adds the redirect to enterprise login page 

#### JIRA

[VAN-1934](https://2u-internal.atlassian.net/browse/VAN-1934)

#### How Has This Been Tested?

Added tests for the existence of the link

#### Screenshots/sandbox (optional):

https://github.com/edx/frontend-component-authn-edx/assets/40633976/7ca92e90-ae25-4062-8f6d-56a49f775243


#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
