### PR TITLE
feat: implement in-popup redirections

### DIFF
--- a/src/authn-component/data/reducers.js
+++ b/src/authn-component/data/reducers.js
@@ -5,13 +5,14 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 import {
-  COMPLETE_STATE, DEFAULT_STATE, FAILURE_STATE, PENDING_STATE,
+  COMPLETE_STATE, DEFAULT_STATE, FAILURE_STATE, PENDING_STATE, REGISTRATION_FORM,
 } from '../../data/constants';
 
 export const commonDataStoreName = 'commonData';
 export const COMMON_DATA_SLICE_NAME = 'commonData';
 
 export const commonDataInitialState = {
+  currentForm: REGISTRATION_FORM,
   thirdPartyAuthApiStatus: DEFAULT_STATE,
   thirdPartyAuthContext: {
     autoSubmitRegForm: false,
@@ -42,6 +43,9 @@ export const commonDataSlice = createSlice({
     clearThirdPartyAuthContextErrorMessage: (state) => {
       state.thirdPartyAuthContext.errorMessage = null;
     },
+    setCurrentOpenedForm: (state, { payload: currentForm }) => {
+      state.currentForm = currentForm;
+    },
   },
 });
 
@@ -50,6 +54,7 @@ export const {
   getThirdPartyAuthContextSuccess,
   getThirdPartyAuthContextFailed,
   clearThirdPartyAuthContextErrorMessage,
+  setCurrentOpenedForm,
 } = commonDataSlice.actions;
 
 export default commonDataSlice.reducer;

--- a/src/authn-component/data/tests/reducer.test.js
+++ b/src/authn-component/data/tests/reducer.test.js
@@ -1,12 +1,12 @@
 import {
-  COMPLETE_STATE, FAILURE_STATE, PENDING_STATE,
+  COMPLETE_STATE, FAILURE_STATE, LOGIN_FORM, PENDING_STATE,
 } from '../../../data/constants';
 import commonDataReducer, {
   clearThirdPartyAuthContextErrorMessage,
   commonDataInitialState,
   getThirdPartyAuthContext,
   getThirdPartyAuthContextFailed,
-  getThirdPartyAuthContextSuccess,
+  getThirdPartyAuthContextSuccess, setCurrentOpenedForm,
 } from '../reducers';
 
 describe('commonDataSlice reducer', () => {
@@ -48,5 +48,11 @@ describe('commonDataSlice reducer', () => {
     const nextState = commonDataReducer(commonDataInitialState, clearThirdPartyAuthContextErrorMessage());
 
     expect(nextState.thirdPartyAuthContext.errorMessage).toBeNull();
+  });
+
+  it('should handle setCurrentOpenedForm action', () => {
+    const nextState = commonDataReducer(commonDataInitialState, setCurrentOpenedForm(LOGIN_FORM));
+
+    expect(nextState.currentForm).toEqual(LOGIN_FORM);
   });
 });

--- a/src/common-ui/InlineLink/index.jsx
+++ b/src/common-ui/InlineLink/index.jsx
@@ -3,28 +3,62 @@ import React from 'react';
 import { Hyperlink } from '@openedx/paragon';
 import PropTypes from 'prop-types';
 
+/**
+ * A component that serves two purposes:
+ * 1. External redirection with `destination`.
+ * 2. Internal redirection with `onClick`.
+ *
+ * When `destination` is provided, clicking the link will navigate to the specified URL.
+ * If `onClick` is provided, clicking the link will trigger the `onClick` function instead of navigating externally.
+ *
+ * @param {string} className - Additional class name for styling.
+ * @param {string} destination - The URL to redirect to when clicked. Only used if `onClick` is `null`.
+ * @param {string} linkHelpText - The help text displayed alongside the link.
+ * @param {string} linkText - The text displayed for the link.
+ * @param {Function} onClick - The function to call when the link is clicked. If provided, `destination` is ignored.
+ */
 const InlineLink = ({
-  className, destination, linkHelpText, linkText,
-}) => (
-  <div className={`d-flex popup-container_inline-link_container ${className}`}>
-    <span className="text-gray-800">
-      {linkHelpText}
-    </span>
-    <Hyperlink className="popup-container_inline-link_hyperlink" destination={destination} isInline>
-      {linkText}
-    </Hyperlink>
-  </div>
-);
+  className, destination, linkHelpText, linkText, onClick,
+}) => {
+  const handleClick = (e) => {
+    if (onClick) {
+      e.preventDefault();
+      onClick();
+    }
+  };
+
+  return (
+    <div className={`d-flex popup-container_inline-link_container ${className}`}>
+      {linkHelpText && (
+        <span className="text-gray-800">
+          {linkHelpText}
+        </span>
+      )}
+      <Hyperlink
+        className="popup-container_inline-link_hyperlink"
+        destination={destination}
+        onClick={handleClick}
+        isInline
+      >
+        {linkText}
+      </Hyperlink>
+    </div>
+  );
+};
 
 InlineLink.propTypes = {
   className: PropTypes.string,
-  destination: PropTypes.string.isRequired,
-  linkHelpText: PropTypes.string.isRequired,
+  destination: PropTypes.string,
+  onClick: PropTypes.func,
+  linkHelpText: PropTypes.string,
   linkText: PropTypes.string.isRequired,
 };
 
 InlineLink.defaultProps = {
+  linkHelpText: '',
   className: '',
+  destination: '',
+  onClick: null,
 };
 
 export default InlineLink;

--- a/src/common-ui/InlineLink/index.test.jsx
+++ b/src/common-ui/InlineLink/index.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+
+import InlineLink from './index';
+
+const mockWindow = window;
+
+jest.mock('@openedx/paragon', () => ({
+  // eslint-disable-next-line react/prop-types
+  Hyperlink: ({ children, destination, onClick }) => (
+    // eslint-disable-next-line jsx-a11y/anchor-is-valid
+    <a
+      href={destination}
+      onClick={(e) => {
+        if (onClick) { onClick(e); }
+        mockWindow.location.href = destination;
+      }}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+describe('InlineLink', () => {
+  it('should render link with help text and trigger onClick when clicked', () => {
+    const onClickMock = jest.fn();
+    const { getByText } = render(
+      <InlineLink
+        linkText="Test Link"
+        linkHelpText="Help text"
+        onClick={onClickMock}
+        destination="https://example.com"
+      />,
+    );
+
+    const link = getByText('Test Link');
+    const helpText = getByText('Help text');
+
+    fireEvent.click(link);
+
+    expect(onClickMock).toHaveBeenCalled();
+    expect(helpText).toBeTruthy();
+  });
+
+  it('should render link with destination and not trigger onClick when clicked', () => {
+    const { getByText } = render(
+      <InlineLink
+        linkText="Test Link"
+        destination="https://example.com"
+      />,
+    );
+
+    delete window.location;
+    window.location = { href: 'http://base-url.com' };
+
+    expect(window.location.href).toEqual('http://base-url.com');
+
+    const link = getByText('Test Link');
+    fireEvent.click(link);
+
+    expect(window.location.href).toEqual('https://example.com');
+  });
+});

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,6 +1,8 @@
 // Forms
 export const LOGIN_FORM = 'login';
 export const REGISTRATION_FORM = 'registration';
+export const FORGOT_PASSWORD_FORM = 'forgot-password';
+export const PROGRESSIVE_PROFILING_FORM = 'progressive-profiling';
 export const VALID_FORMS = [LOGIN_FORM, REGISTRATION_FORM];
 
 // Common States

--- a/src/forms/common-components/AuthenticatedRedirection.jsx
+++ b/src/forms/common-components/AuthenticatedRedirection.jsx
@@ -1,13 +1,22 @@
+import { useDispatch } from 'react-redux';
+
 import { getConfig } from '@edx/frontend-platform';
 import PropTypes from 'prop-types';
 
+import { setCurrentOpenedForm } from '../../authn-component/data/reducers';
+import { PROGRESSIVE_PROFILING_FORM } from '../../data/constants';
+
 /**
  * Component that handles redirection after successful authentication.
- * Redirects to the finishAuthUrl if provided and not already included in redirectUrl,
+ *
+ * Redirections:
+ * - Redirects to progressive profiling form if redirectToProgressiveProfilingForm is true.
+ * - Redirects to the finishAuthUrl if provided and not already included in redirectUrl,
  * otherwise redirects to the specified redirectUrl.
  *
  * @param {string} finishAuthUrl - The URL to complete the authentication pipeline.
  * @param {string} redirectUrl - The URL to redirect to after authentication.
+ * @param {boolean} redirectToProgressiveProfilingForm - Flag indicating if to redirect to progressive profiling.
  * @param {boolean} success - Flag indicating if authentication was successful.
  *
  * @returns {null} This component does not render anything, it handles redirects.
@@ -15,8 +24,11 @@ import PropTypes from 'prop-types';
 const AuthenticatedRedirection = ({
   finishAuthUrl,
   redirectUrl,
+  redirectToProgressiveProfilingForm,
   success,
 }) => {
+  const dispatch = useDispatch();
+
   if (success) {
     let finalRedirectUrl = '';
 
@@ -30,6 +42,12 @@ const AuthenticatedRedirection = ({
       finalRedirectUrl = redirectUrl;
     }
 
+    // Redirect to Progressive Profiling after successful registration
+    if (redirectToProgressiveProfilingForm) {
+      dispatch(setCurrentOpenedForm(PROGRESSIVE_PROFILING_FORM));
+      return null;
+    }
+
     window.location.href = finalRedirectUrl;
   }
 
@@ -40,12 +58,14 @@ AuthenticatedRedirection.defaultProps = {
   finishAuthUrl: null,
   success: false,
   redirectUrl: '',
+  redirectToProgressiveProfilingForm: false,
 };
 
 AuthenticatedRedirection.propTypes = {
   finishAuthUrl: PropTypes.string,
   success: PropTypes.bool,
   redirectUrl: PropTypes.string,
+  redirectToProgressiveProfilingForm: PropTypes.bool,
 };
 
 export default AuthenticatedRedirection;

--- a/src/forms/common-components/tests/AuthenticatedRedirection.test.jsx
+++ b/src/forms/common-components/tests/AuthenticatedRedirection.test.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 
+import { IntlProvider } from '@edx/frontend-platform/i18n';
 import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
 
+import { setCurrentOpenedForm } from '../../../authn-component/data/reducers';
+import { PROGRESSIVE_PROFILING_FORM } from '../../../data/constants';
 import AuthenticatedRedirection from '../AuthenticatedRedirection';
+
+const mockStore = configureStore();
 
 jest.mock('@edx/frontend-platform', () => ({
   getConfig: jest.fn(() => ({ LMS_BASE_URL: 'http://example.com' })),
@@ -14,44 +22,79 @@ describe('AuthenticatedRedirection', () => {
   const mockRedirectUrl = 'http://example.com/redirect';
   const mockSuccess = true;
 
+  let store = {};
+
+  const reduxWrapper = children => (
+    <IntlProvider locale="en">
+      <MemoryRouter>
+        <Provider store={store}>{children}</Provider>
+      </MemoryRouter>
+    </IntlProvider>
+  );
+
+  const initialState = {
+    commonData: {
+      thirdPartyAuthContext: {
+        finishAuthUrl: null,
+        providers: [],
+        errorMessage: null,
+      },
+    },
+  };
+
   beforeEach(() => {
+    store = mockStore(initialState);
     delete window.location;
     window.location = { href: '' };
   });
 
   it('should not redirect if success is false', () => {
-    render(
+    render(reduxWrapper(
       <AuthenticatedRedirection
         finishAuthUrl={mockFinishAuthUrl}
         redirectUrl={mockRedirectUrl}
         success={false}
       />,
-    );
+    ));
 
     expect(window.location.href).toBe('');
   });
 
   it('should redirect to finishAuthUrl if provided and not already included in redirectUrl', () => {
-    render(
+    render(reduxWrapper(
       <AuthenticatedRedirection
         finishAuthUrl={mockFinishAuthUrl}
         redirectUrl={mockRedirectUrl}
         success={mockSuccess}
       />,
-    );
+    ));
 
     expect(window.location.href).toBe(`${LMS_BASE_URL_MOCK}${mockFinishAuthUrl}`);
   });
 
   it('should redirect to redirectUrl if finishAuthUrl is not provided or already included in redirectUrl', () => {
-    render(
+    render(reduxWrapper(
       <AuthenticatedRedirection
         finishAuthUrl={null}
         redirectUrl={mockRedirectUrl + mockFinishAuthUrl} // finishAuthUrl already included
         success={mockSuccess}
       />,
-    );
+    ));
 
     expect(window.location.href).toBe(`${mockRedirectUrl + mockFinishAuthUrl}`);
+  });
+
+  it('should redirect to progressive profiling if redirectToProgressiveProfilingForm is true', () => {
+    store.dispatch = jest.fn(store.dispatch);
+    render(reduxWrapper(
+      <AuthenticatedRedirection
+        finishAuthUrl={null}
+        redirectUrl={mockRedirectUrl + mockFinishAuthUrl} // finishAuthUrl already included
+        success={mockSuccess}
+        redirectToProgressiveProfilingForm
+      />,
+    ));
+
+    expect(store.dispatch).toHaveBeenCalledWith(setCurrentOpenedForm(PROGRESSIVE_PROFILING_FORM));
   });
 });

--- a/src/forms/login-popup/index.jsx
+++ b/src/forms/login-popup/index.jsx
@@ -4,15 +4,18 @@ import { useDispatch, useSelector } from 'react-redux';
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
-  Container, Form, Hyperlink, StatefulButton,
+  Container, Form, StatefulButton,
 } from '@openedx/paragon';
 
 import LoginFailureAlert from './components/LoginFailureAlert';
 import { TPA_AUTHENTICATION_FAILURE } from './data/constants';
 import { loginUser } from './data/reducers';
 import messages from './messages';
+import { setCurrentOpenedForm } from '../../authn-component/data/reducers';
 import { InlineLink, SocialAuthProviders } from '../../common-ui';
-import { ENTERPRISE_LOGIN_URL, INVALID_FORM } from '../../data/constants';
+import {
+  ENTERPRISE_LOGIN_URL, FORGOT_PASSWORD_FORM, INVALID_FORM, REGISTRATION_FORM,
+} from '../../data/constants';
 import getAllPossibleQueryParams from '../../data/utils';
 import AuthenticatedRedirection from '../common-components/AuthenticatedRedirection';
 import ThirdPartyAuthAlert from '../common-components/ThirdPartyAuthAlert';
@@ -157,10 +160,11 @@ const LoginForm = () => {
           floatingLabel={formatMessage(messages.loginFormPasswordFieldLabel)}
           showPasswordTooltip={false}
         />
-        {/* TODO: this destination will be replaced with actual links */}
-        <Hyperlink className="hyper-link" destination="#" isInline>
-          {formatMessage(messages.loginFormForgotPasswordButton)}
-        </Hyperlink>
+        <InlineLink
+          className="hyper-link"
+          onClick={() => dispatch(setCurrentOpenedForm(FORGOT_PASSWORD_FORM))}
+          linkText={formatMessage(messages.loginFormForgotPasswordButton)}
+        />
         <div className="d-flex flex-column my-4">
           <StatefulButton
             id="login-user"
@@ -179,7 +183,7 @@ const LoginForm = () => {
         </div>
         <InlineLink
           className="mb-2"
-          destination="#"
+          onClick={() => dispatch(setCurrentOpenedForm(REGISTRATION_FORM))}
           linkHelpText={formatMessage(messages.loginFormRegistrationHelpText)}
           linkText={formatMessage(messages.loginFormRegistrationLink)}
         />

--- a/src/forms/login-popup/tests/index.test.jsx
+++ b/src/forms/login-popup/tests/index.test.jsx
@@ -7,7 +7,10 @@ import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
-import { DEFAULT_STATE, INTERNAL_SERVER_ERROR } from '../../../data/constants';
+import { setCurrentOpenedForm } from '../../../authn-component/data/reducers';
+import {
+  DEFAULT_STATE, FORGOT_PASSWORD_FORM, INTERNAL_SERVER_ERROR, REGISTRATION_FORM,
+} from '../../../data/constants';
 import getAllPossibleQueryParams from '../../../data/utils';
 import { loginUser } from '../data/reducers';
 import LoginForm from '../index';
@@ -316,5 +319,23 @@ describe('LoginForm Test', () => {
     loginButton.onmousedown = preventDefaultMock;
     fireEvent.mouseDown(loginButton);
     expect(preventDefaultMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dispatch setCurrentOpenedForm action on "Create account" link click', () => {
+    store.dispatch = jest.fn(store.dispatch);
+    const { getByText } = render(reduxWrapper(<IntlLoginForm />));
+
+    fireEvent.click(getByText('Create account'));
+
+    expect(store.dispatch).toHaveBeenCalledWith(setCurrentOpenedForm(REGISTRATION_FORM));
+  });
+
+  it('should dispatch setCurrentOpenedForm action on "Forgot Password?" link click', () => {
+    store.dispatch = jest.fn(store.dispatch);
+    const { getByText } = render(reduxWrapper(<IntlLoginForm />));
+
+    fireEvent.click(getByText('Forgot Password?'));
+
+    expect(store.dispatch).toHaveBeenCalledWith(setCurrentOpenedForm(FORGOT_PASSWORD_FORM));
   });
 });

--- a/src/forms/progressive-profiling-popup/index.jsx
+++ b/src/forms/progressive-profiling-popup/index.jsx
@@ -43,7 +43,10 @@ const ProgressiveProfilingForm = () => {
   return (
     <BaseContainer open setOpen={() => {}}>
       <Container size="lg" className="authn__popup-container overflow-auto">
-        <h1 className="display-1 font-italic text-center mb-4">
+        <h1
+          className="display-1 font-italic text-center mb-4"
+          data-testid="progressive-profiling-heading"
+        >
           {formatMessage(messages.progressiveProfilingFormHeading)}
         </h1>
         <p className="text-center">

--- a/src/forms/registration-popup/index.jsx
+++ b/src/forms/registration-popup/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -11,9 +11,11 @@ import { ArrowBack } from '@openedx/paragon/icons';
 import { NUM_OF_STEPS, STEP1, STEP2 } from './data/constants';
 import { registerUser } from './data/reducers';
 import messages from './messages';
+import { setCurrentOpenedForm } from '../../authn-component/data/reducers';
 import { InlineLink, SocialAuthProviders } from '../../common-ui';
-import { ENTERPRISE_LOGIN_URL } from '../../data/constants';
+import { ENTERPRISE_LOGIN_URL, LOGIN_FORM } from '../../data/constants';
 import './index.scss';
+import AuthenticatedRedirection from '../common-components/AuthenticatedRedirection';
 import EmailField from '../fields/email-field';
 import MarketingEmailOptInCheckbox from '../fields/marketing-email-opt-out-field';
 import PasswordField from '../fields/password-field';
@@ -32,6 +34,9 @@ const RegistrationForm = () => {
     name: '', email: '', password: '', marketingEmailOptIn: true,
   });
   const [currentStep, setCurrentStep] = useState(STEP1);
+
+  const registrationResult = useSelector(state => state.register.registrationResult);
+  const finishAuthUrl = useSelector(state => state.commonData.thirdPartyAuthContext.finishAuthUrl);
 
   const handleOnChange = (event) => {
     const { name } = event.target;
@@ -85,6 +90,11 @@ const RegistrationForm = () => {
   return (
     <Stepper activeKey={`step${currentStep}`}>
       <Container size="lg" className="authn__popup-container overflow-auto">
+        <AuthenticatedRedirection
+          success={registrationResult.success}
+          redirectUrl={registrationResult.redirectUrl}
+          finishAuthUrl={finishAuthUrl}
+        />
         {Header}
         {currentStep > STEP1 && (
           <div className="back-button-container mb-4">
@@ -174,7 +184,7 @@ const RegistrationForm = () => {
         <div>
           <InlineLink
             className="mb-2"
-            destination="#"
+            onClick={() => dispatch(setCurrentOpenedForm(LOGIN_FORM))}
             linkHelpText={formatMessage(messages.registrationFormAlreadyHaveAccountText)}
             linkText={formatMessage(messages.registrationFormSignInLink)}
           />

--- a/src/forms/reset-password-popup/ResetPasswordHeader.jsx
+++ b/src/forms/reset-password-popup/ResetPasswordHeader.jsx
@@ -14,7 +14,10 @@ const ResetPasswordHeader = () => {
 
   return (
     <>
-      <h2 className="font-italic text-center display-1 mb-4 text-dark-500">
+      <h2
+        className="font-italic text-center display-1 mb-4 text-dark-500"
+        data-testid="forgot-password-heading"
+      >
         {formatMessage(messages.resetPasswordFormHeading)}
       </h2>
       <hr className="separator mb-3 mt-3" />

--- a/src/forms/reset-password-popup/forgot-password/ForgotPasswordForm.jsx
+++ b/src/forms/reset-password-popup/forgot-password/ForgotPasswordForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
 
 import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -7,18 +8,22 @@ import {
 } from '@openedx/paragon';
 
 import ForgotPasswordEmailSentConfirmation from './ForgotPasswordEmailSentConfirmation';
+import { setCurrentOpenedForm } from '../../../authn-component/data/reducers';
 import { InlineLink } from '../../../common-ui';
+import { LOGIN_FORM } from '../../../data/constants';
 import EmailField from '../../fields/email-field';
 import messages from '../messages';
 import ResetPasswordHeader from '../ResetPasswordHeader';
+
 import '../index.scss';
 
 /**
  * ForgotPasswordForm component for handling user password reset.
  * This component provides a form for users to reset their password by entering their email.
  */
-const ForgotPasswordPage = () => {
+const ForgotPasswordForm = () => {
   const { formatMessage } = useIntl();
+  const dispatch = useDispatch();
 
   const [formFields, setFormFields] = useState({ email: '' });
   const [isSuccess, setIsSuccess] = useState(false);
@@ -32,6 +37,7 @@ const ForgotPasswordPage = () => {
   const handleSubmit = (e) => {
     e.preventDefault();
     setIsSuccess(true);
+    dispatch(setCurrentOpenedForm(LOGIN_FORM));
   };
 
   return (
@@ -92,4 +98,4 @@ const ForgotPasswordPage = () => {
   );
 };
 
-export default ForgotPasswordPage;
+export default ForgotPasswordForm;


### PR DESCRIPTION
### Description

This PR implements In-popup redirections
Login → Signup
Signup → Login
Login → Forgot password
Signup → Progressive profiling

TODO: 

we don't have forgot password form so it will done later, I have added code although.
Progressive profiling page Is buggy so its test will be fixed once its done.

#### JIRA
[VAN-1933](https://2u-internal.atlassian.net/browse/VAN-1933)

#### How Has This Been Tested?

Local Env Testing
Testing with unit tests

#### Screenshots/sandbox (optional):

https://github.com/edx/frontend-component-authn-edx/assets/52817156/b5b98882-dcde-4aab-bf42-b53ce14d2809

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

