### PR TITLE
feat: Update design of progressive profiling

### DIFF
--- a/src/authn-component/index.jsx
+++ b/src/authn-component/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { AppProvider } from '@edx/frontend-platform/react';
@@ -40,6 +40,9 @@ export const AuthnComponent = ({
   const dispatch = useDispatch();
   const queryParams = useMemo(() => getAllPossibleQueryParams(), []);
 
+  const [screenSize, setScreenSize] = useState('lg');
+  const [hasCloseButton, setHasCloseButton] = useState(true);
+
   const currentForm = useSelector(state => state.commonData.currentForm);
   const providers = useSelector(state => state.commonData.thirdPartyAuthContext?.providers);
   const secondaryProviders = useSelector(state => state.commonData.thirdPartyAuthContext?.secondaryProviders);
@@ -48,6 +51,13 @@ export const AuthnComponent = ({
   const tpaHint = getTpaHint();
   const { provider: tpaProvider } = getTpaProvider(tpaHint, providers, secondaryProviders);
   const pendingState = queryParams?.tpa_hint && thirdPartyAuthApiStatus === PENDING_STATE;
+
+  useEffect(() => {
+    if (currentForm === PROGRESSIVE_PROFILING_FORM) {
+      setHasCloseButton(false);
+      setScreenSize('fullscreen');
+    }
+  }, [currentForm]);
 
   useEffect(() => {
     if (tpaProvider) {
@@ -92,7 +102,12 @@ export const AuthnComponent = ({
   );
 
   return (
-    <BaseContainer isOpen={isOpen} close={close}>
+    <BaseContainer
+      isOpen={isOpen}
+      close={close}
+      hasCloseButton={hasCloseButton}
+      size={screenSize}
+    >
       {pendingState
         ? getSpinner
         : getForm()}

--- a/src/authn-component/tests/index.test.jsx
+++ b/src/authn-component/tests/index.test.jsx
@@ -185,8 +185,7 @@ describe('AuthnComponent Test', () => {
       expect(getByTestId('sign-up-heading')).toBeTruthy();
     });
 
-    // TODO: this test will be fixed when progressive profiling form is fixed.
-    it.skip('renders PROGRESSIVE_PROFILING_FORM form if currentForm=PROGRESSIVE_PROFILING_FORM', () => {
+    it('renders PROGRESSIVE_PROFILING_FORM form if currentForm=PROGRESSIVE_PROFILING_FORM', () => {
       getLocale.mockImplementation(() => ('en-us'));
       store = mockStore({
         ...initialState,
@@ -195,10 +194,12 @@ describe('AuthnComponent Test', () => {
           currentForm: PROGRESSIVE_PROFILING_FORM,
         },
       });
-      const { getByTestId } = render(reduxWrapper(
+      const { container, getByTestId } = render(reduxWrapper(
         <IntlAuthnComponent isOpen close={() => {}} />,
       ));
+      const closeButton = container.querySelector('.btn-icon__icon');
 
+      expect(closeButton).toBeFalsy();
       expect(getByTestId('progressive-profiling-heading')).toBeTruthy();
     });
 

--- a/src/base-container/index.jsx
+++ b/src/base-container/index.jsx
@@ -15,19 +15,19 @@ import './index.scss';
  * @returns {JSX.Element} The rendered login or registration form modal.
  */
 const BaseContainer = ({
-  children, isOpen, close,
+  children, close, hasCloseButton, isOpen, size,
 }) => (
   <ModalDialog
     isOpen={isOpen}
     onClose={close}
-    size="lg"
+    size={size}
     variant="default"
     title="authn-component"
     className="bg-light-200 authn-component__modal"
-    hasCloseButton
+    hasCloseButton={hasCloseButton}
   >
     <ModalDialog.Body className="modal-body-container p-0">
-      <div className="d-flex w-100 h-100 flex-column overflow-hidden">
+      <div className="d-flex w-100 h-100 justify-content-center overflow-hidden">
         {children}
       </div>
     </ModalDialog.Body>
@@ -38,6 +38,13 @@ BaseContainer.propTypes = {
   children: PropTypes.node.isRequired,
   isOpen: PropTypes.bool.isRequired,
   close: PropTypes.func.isRequired,
+  size: PropTypes.string,
+  hasCloseButton: PropTypes.bool,
+};
+
+BaseContainer.defaultProps = {
+  size: 'lg',
+  hasCloseButton: true,
 };
 
 export default BaseContainer;

--- a/src/forms/progressive-profiling-popup/index.jsx
+++ b/src/forms/progressive-profiling-popup/index.jsx
@@ -9,7 +9,6 @@ import { Language } from '@openedx/paragon/icons';
 import './index.scss';
 import { optionalFieldsData } from './data/constants';
 import messages from './messages';
-import BaseContainer from '../../base-container';
 
 /**
  * Progressive profiling form component. This component holds the logic to render optional demographic
@@ -41,119 +40,122 @@ const ProgressiveProfilingForm = () => {
   ));
 
   return (
-    <BaseContainer open setOpen={() => {}}>
-      <Container size="lg" className="authn__popup-container overflow-auto">
-        <h1
-          className="display-1 font-italic text-center mb-4"
-          data-testid="progressive-profiling-heading"
-        >
-          {formatMessage(messages.progressiveProfilingFormHeading)}
-        </h1>
-        <p className="text-center">
-          {formatMessage(messages.progressiveProfilingCompletionSkipMessage)}
+    <Container size="lg" className="authn__popup-progressive-profiling-container m-0 overflow-auto">
+      <h1
+        className="display-1 font-italic text-center mb-4"
+        data-testid="progressive-profiling-heading"
+      >
+        {formatMessage(messages.progressiveProfilingFormHeading)}
+      </h1>
+      <p className="text-center">
+        {formatMessage(messages.progressiveProfilingCompletionSkipMessage)}
+      </p>
+      <hr className="heading-separator mb-3 mt-3" />
+      <Form id="progressive-profiling" name="progressive-profiling">
+        <h3 className="mb-2.5 mt-2">
+          {formatMessage(messages.progressiveProfilingCountryFieldTitle)}
+        </h3>
+        <p className="x-small">
+          {formatMessage(messages.progressiveProfilingCountryFieldInfoMessage)}
         </p>
-        <hr className="heading-separator mb-3 mt-3" />
-        <Form id="progressive-profiling" name="progressive-profiling">
-          <h3 className="mb-2.5 mt-2">
-            {formatMessage(messages.progressiveProfilingCountryFieldTitle)}
-          </h3>
-          <p className="x-small">
-            {formatMessage(messages.progressiveProfilingCountryFieldInfoMessage)}
-          </p>
-          <Form.Group controlId="country" className="mb-4.5">
-            <Form.Autosuggest
-              name="country"
-              placeholder={formatMessage(messages.useProfileCountryFieldUndetected)}
-              leadingElement={<Icon src={Language} />}
-            >
-              {getCountryFieldOptions()}
-            </Form.Autosuggest>
-            <Form.Control.Feedback>
-              {formatMessage(messages.progressiveProfilingCountryFieldHelpText)}
-            </Form.Control.Feedback>
-          </Form.Group>
-          <h3 className="mb-2.5">
-            {formatMessage(messages.progressiveProfilingDataCollectionTitle)}
-          </h3>
-          <Form.Group controlId="subject" className="mb-4.5">
-            <Form.Label>
-              {formatMessage(messages.progressiveProfilingSubjectFieldLabel)}
-            </Form.Label>
-            <Form.Autosuggest
-              name="subject"
-              placeholder={formatMessage(messages.progressiveProfilingSubjectFieldPlaceholder)}
-            >
-              {getFieldOptions('subject', optionalFieldsData.subject)}
-            </Form.Autosuggest>
-          </Form.Group>
-          <Form.Group controlId="level-of-education" className="mb-4.5">
-            <Form.Label>
-              {formatMessage(messages.progressiveProfilingLevelOfEducationFieldLabel)}
-            </Form.Label>
-            <Form.Autosuggest
-              name="level-of-education"
-              placeholder={formatMessage(messages.progressiveProfilingLevelOfEducationFieldPlaceholder)}
-            >
-              {getFieldOptions('levelOfEducation', optionalFieldsData.levelOfEducation)}
-            </Form.Autosuggest>
-          </Form.Group>
-          <Form.Group controlId="work-experience" className="mb-4.5">
-            <Form.Label>
-              {formatMessage(messages.progressiveProfilingWorkExperienceFieldLabel)}
-            </Form.Label>
-            <Form.Autosuggest
-              name="work-experience"
-              placeholder={formatMessage(messages.progressiveProfilingWorkExperienceFieldPlaceholder)}
-            >
-              {getFieldOptions('workExperience', optionalFieldsData.workExperience)}
-            </Form.Autosuggest>
-          </Form.Group>
-          <Form.Group controlId="learning-type" className="mb-4.5">
-            <Form.Label>
-              {formatMessage(messages.progressiveProfilingLearningTypeFieldLabel)}
-            </Form.Label>
-            <Form.Autosuggest
-              name="learning-type"
-              placeholder={formatMessage(messages.progressiveProfilingLearningTypeFieldPlaceholder)}
-            >
-              {getFieldOptions('learningType', optionalFieldsData.learningType)}
-            </Form.Autosuggest>
-          </Form.Group>
-          <Form.Group controlId="gender" className="mb-4.5">
-            <Form.Label>
-              {formatMessage(messages.progressiveProfilingGenderFieldLabel)}
-            </Form.Label>
-            <Form.Autosuggest
-              name="gender"
-              placeholder={formatMessage(messages.progressiveProfilingGenderFieldPlaceholder)}
-            >
-              {getFieldOptions('gender', optionalFieldsData.gender)}
-            </Form.Autosuggest>
-          </Form.Group>
-          <div className="d-flex my-4 justify-content-end progressive-profiling__cta-btn-container">
-            <Button
-              id="skip-optional-fields"
-              name="skip-optional-fields"
-              type="submit"
-              variant="outline-dark"
-              onClick={() => {}}
-              onMouseDown={(e) => e.preventDefault()}
-            >
-              {formatMessage(messages.progressiveProfilingSkipForNowButtonText)}
-            </Button>
-            <Button
-              id="submit-optional-fields"
-              name="submit-optional-fields"
-              type="submit"
-              onClick={() => {}}
-              onMouseDown={(e) => e.preventDefault()}
-            >
-              {formatMessage(messages.progressiveProfilingSubmitButtonText)}
-            </Button>
-          </div>
-        </Form>
-      </Container>
-    </BaseContainer>
+        <Form.Group controlId="country" className="mb-4.5">
+          <Form.Autosuggest
+            name="country"
+            placeholder={formatMessage(messages.useProfileCountryFieldUndetected)}
+            leadingElement={<Icon src={Language} />}
+          >
+            {getCountryFieldOptions()}
+          </Form.Autosuggest>
+          <Form.Control.Feedback>
+            {formatMessage(messages.progressiveProfilingCountryFieldHelpText)}
+          </Form.Control.Feedback>
+        </Form.Group>
+        <h3 className="mb-2.5">
+          {formatMessage(messages.progressiveProfilingDataCollectionTitle)}
+        </h3>
+        <Form.Group controlId="subject" className="mb-4">
+          <Form.Label>
+            {formatMessage(messages.progressiveProfilingSubjectFieldLabel)}
+          </Form.Label>
+          <Form.Autosuggest
+            name="subject"
+            placeholder={formatMessage(messages.progressiveProfilingSubjectFieldPlaceholder)}
+          >
+            {getFieldOptions('subject', optionalFieldsData.subject)}
+          </Form.Autosuggest>
+        </Form.Group>
+        <Form.Group controlId="level-of-education" className="mb-4">
+          <Form.Label>
+            {formatMessage(messages.progressiveProfilingLevelOfEducationFieldLabel)}
+          </Form.Label>
+          <Form.Autosuggest
+            name="level-of-education"
+            placeholder={formatMessage(messages.progressiveProfilingLevelOfEducationFieldPlaceholder)}
+          >
+            {getFieldOptions('levelOfEducation', optionalFieldsData.levelOfEducation)}
+          </Form.Autosuggest>
+        </Form.Group>
+        <Form.Group controlId="work-experience" className="mb-4">
+          <Form.Label>
+            {formatMessage(messages.progressiveProfilingWorkExperienceFieldLabel)}
+          </Form.Label>
+          <Form.Autosuggest
+            name="work-experience"
+            placeholder={formatMessage(messages.progressiveProfilingWorkExperienceFieldPlaceholder)}
+          >
+            {getFieldOptions('workExperience', optionalFieldsData.workExperience)}
+          </Form.Autosuggest>
+        </Form.Group>
+        <Form.Group controlId="learning-type" className="mb-4">
+          <Form.Label>
+            {formatMessage(messages.progressiveProfilingLearningTypeFieldLabel)}
+          </Form.Label>
+          <Form.Autosuggest
+            name="learning-type"
+            placeholder={formatMessage(messages.progressiveProfilingLearningTypeFieldPlaceholder)}
+          >
+            {getFieldOptions('learningType', optionalFieldsData.learningType)}
+          </Form.Autosuggest>
+        </Form.Group>
+        <Form.Group controlId="gender" className="mb-4">
+          <Form.Label>
+            {formatMessage(messages.progressiveProfilingGenderFieldLabel)}
+          </Form.Label>
+          <Form.RadioSet
+            name="gender"
+            onChange={() => {}}
+            isInline
+          >
+            {optionalFieldsData.gender.options.map(option => (
+              <Form.Radio value={option.label}>
+                {formatMessage(messages[`gender.option.${option.label}`])}
+              </Form.Radio>
+            ))}
+          </Form.RadioSet>
+        </Form.Group>
+        <div className="d-flex my-4 justify-content-end progressive-profiling__cta-btn-container">
+          <Button
+            id="skip-optional-fields"
+            name="skip-optional-fields"
+            type="submit"
+            variant="outline-dark"
+            onClick={() => {}}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {formatMessage(messages.progressiveProfilingSkipForNowButtonText)}
+          </Button>
+          <Button
+            id="submit-optional-fields"
+            name="submit-optional-fields"
+            type="submit"
+            onClick={() => {}}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {formatMessage(messages.progressiveProfilingSubmitButtonText)}
+          </Button>
+        </div>
+      </Form>
+    </Container>
   );
 };
 

--- a/src/forms/progressive-profiling-popup/index.scss
+++ b/src/forms/progressive-profiling-popup/index.scss
@@ -1,3 +1,13 @@
 .progressive-profiling__cta-btn-container {
   gap: 12px;
 }
+
+.authn__popup-progressive-profiling-container {
+  padding: 7.5rem 4rem;
+  @media (max-width: 767px) {
+    padding: 2.5rem 1.5rem;
+  }
+  @media (max-width: 576px) {
+    padding: 2.5rem 1rem;
+  }
+}

--- a/src/forms/progressive-profiling-popup/messages.js
+++ b/src/forms/progressive-profiling-popup/messages.js
@@ -368,7 +368,7 @@ const messages = defineMessages({
   },
   'gender.option.o': {
     id: 'gender.option.o',
-    defaultMessage: 'Other/Prefer Not to Say',
+    defaultMessage: 'Other/prefer not to answer',
     description: 'Option for gender field',
   },
 });

--- a/src/forms/registration-popup/index.jsx
+++ b/src/forms/registration-popup/index.jsx
@@ -54,7 +54,7 @@ const RegistrationForm = () => {
   };
 
   return (
-    <>
+    <div className="flex-column">
       <Container size="lg" className="authn__popup-container">
         <AuthenticatedRedirection
           success={registrationResult.success}
@@ -137,7 +137,7 @@ const RegistrationForm = () => {
           <HonorCodeAndPrivacyPolicyMessage />
         </p>
       </div>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION
### Description

- fix responsiveness of progressive profiling pop-up
- hide the close button and show progressive profiling pop-up on full-screen
- Use the radio button for the gender question

#### JIRA

[VAN-1949](https://2u-internal.atlassian.net/browse/VAN-1949)

#### How Has This Been Tested?

Locally and through unit tests.
#### Screenshots:
<table>
<tr>
<th>Discreption</th>
<th>Screenshot</th>
</tr>
<tr>
<td>
Large Screen
</td>
<td>
<img width="1434" alt="Screenshot 2024-05-21 at 5 39 23 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/78487564/6bfaeabb-8b5b-400d-9048-10c05b9b5b85">
</td>
</tr>
<tr>
<td>
Small Screen
</td>
<td>
<img width="1195" alt="Screenshot 2024-05-21 at 5 40 05 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/78487564/b9426f96-c04a-466c-be2a-29edf327eab6">
</td>
</tr>
<tr>
<td>
Extra Small Screen
</td>
<td>
<img width="988" alt="Screenshot 2024-05-21 at 5 40 30 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/78487564/686399b7-a77f-4e1e-970c-66aced7b0c04">
</td>
</tr>
<tr>
<td>
Form Fields Padding
</td>
<td>
<img width="1334" alt="Screenshot 2024-05-21 at 5 41 33 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/78487564/7746662d-9661-4df3-a3ec-68cb404cff00">
</td>
</tr>
<tr>
<td>
Gander Field
</td>
<td>
<img width="1198" alt="Screenshot 2024-05-22 at 11 31 50 AM" src="https://github.com/edx/frontend-component-authn-edx/assets/78487564/68f1e9d6-a313-464a-8ed1-517a30d350c0">
</td>
</tr>
</table>

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
