### PR TITLE
fix: Update SSO error message position.

### DIFF
--- a/src/forms/common-components/SSOFailureAlert.jsx
+++ b/src/forms/common-components/SSOFailureAlert.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Alert } from '@openedx/paragon';
+import PropTypes from 'prop-types';
+
+import messages from './messages';
+import { TPA_AUTHENTICATION_FAILURE } from '../../data/constants';
+
+/**
+ * SSOFailureAlert component displays an error alert based on the provided error code.
+ * It accepts the following props:
+ * - errorCode: The error code indicating the type of error.
+ * - context: Additional context for the error, such as error message.
+ * - alertTitle: Optional title for the alert.
+ */
+const SSOFailureAlert = (props) => {
+  const { formatMessage } = useIntl();
+  const { context, errorCode, alertTitle } = props;
+
+  if (!errorCode || errorCode !== TPA_AUTHENTICATION_FAILURE) {
+    return null;
+  }
+  const errorMessage = errorCode === TPA_AUTHENTICATION_FAILURE
+    ? (
+      <span>
+        {formatMessage(messages.TPAAuthenticationFailure, {
+          platform_name: getConfig().SITE_NAME,
+          lineBreak: <br />,
+          errorMessage: context.errorMessage,
+        })}
+      </span>
+    )
+    : null;
+
+  return (
+    <Alert id="SSO-failure-alert" className="mb-4" variant="danger">
+      {alertTitle && formatMessage(alertTitle)} {errorMessage}
+    </Alert>
+  );
+};
+
+SSOFailureAlert.defaultProps = {
+  context: {},
+  alertTitle: null,
+};
+
+SSOFailureAlert.propTypes = {
+  context: PropTypes.shape({
+    errorMessage: PropTypes.string,
+  }),
+  errorCode: PropTypes.string.isRequired,
+  alertTitle: PropTypes.node,
+};
+
+export default SSOFailureAlert;

--- a/src/forms/common-components/messages.jsx
+++ b/src/forms/common-components/messages.jsx
@@ -16,6 +16,13 @@ const messages = defineMessages({
     description: 'Message that appears on register page if user has successfully authenticated with TPA '
                   + 'but no associated platform account exists',
   },
+  TPAAuthenticationFailure: {
+    id: 'tpa.authentication.failure',
+    defaultMessage: 'We are sorry, you are not authorized to access {platform_name} via this channel. '
+        + 'Please contact your learning administrator or manager in order to access {platform_name}.'
+        + '{lineBreak}{lineBreak}Error Details:{lineBreak}{errorMessage}',
+    description: 'Error message third party authentication pipeline fails',
+  },
 });
 
 export default messages;

--- a/src/forms/login-popup/components/LoginFailureAlert.jsx
+++ b/src/forms/login-popup/components/LoginFailureAlert.jsx
@@ -32,7 +32,7 @@ const LoginFailureAlert = (props) => {
   const { formatMessage } = useIntl();
   const { context, errorCode } = props;
 
-  if (!errorCode) {
+  if (!errorCode || errorCode === TPA_AUTHENTICATION_FAILURE) {
     return null;
   }
 
@@ -129,16 +129,6 @@ const LoginFailureAlert = (props) => {
           </span>
         );
       }
-      break;
-    case TPA_AUTHENTICATION_FAILURE:
-      errorMessage = (
-        <span>
-          {formatMessage(messages.loginTpaAuthenticationFailure, {
-            lineBreak: <br />,
-            errorMessage: context.errorMessage,
-          })}
-        </span>
-      );
       break;
     case INTERNAL_SERVER_ERROR:
     default:

--- a/src/forms/login-popup/components/LoginFailureAlert.test.jsx
+++ b/src/forms/login-popup/components/LoginFailureAlert.test.jsx
@@ -13,6 +13,7 @@ import {
   INVALID_FORM,
   TPA_AUTHENTICATION_FAILURE,
 } from '../../../data/constants';
+import SSOFailureAlert from '../../common-components/SSOFailureAlert';
 import {
   ACCOUNT_LOCKED_OUT,
   ALLOWED_DOMAIN_LOGIN_ERROR,
@@ -23,6 +24,7 @@ import {
 } from '../data/constants';
 
 const IntlLoginFailureAlert = injectIntl(LoginFailureAlert);
+const IntlSSOFailureAlert = injectIntl(SSOFailureAlert);
 
 describe('LoginFailureAlert', () => {
   let props = {};
@@ -259,10 +261,10 @@ describe('LoginFailureAlert', () => {
 
     const { container } = render(
       <IntlProvider locale="en">
-        <IntlLoginFailureAlert {...props} />
+        <IntlSSOFailureAlert {...props} />
       </IntlProvider>,
     );
 
-    expect(container.querySelector('#login-failure-alert').textContent).toContain(errorMsg);
+    expect(container.querySelector('#SSO-failure-alert').textContent).toContain(errorMsg);
   });
 });

--- a/src/forms/login-popup/index.jsx
+++ b/src/forms/login-popup/index.jsx
@@ -26,6 +26,7 @@ import {
   trackForgotPasswordLinkClick, trackInstitutionLoginLinkClick, trackLoginPageEvent,
 } from '../../tracking/trackers/login';
 import AuthenticatedRedirection from '../common-components/AuthenticatedRedirection';
+import SSOFailureAlert from '../common-components/SSOFailureAlert';
 import ThirdPartyAuthAlert from '../common-components/ThirdPartyAuthAlert';
 import {
   TextField as EmailOrUsernameField,
@@ -153,6 +154,11 @@ const LoginForm = () => {
         {formatMessage(messages.loginFormHeading1)}
       </h1>
       <hr className="heading-separator my-3 my-sm-4" />
+      <SSOFailureAlert
+        errorCode={errorCode.type}
+        context={errorCode.context}
+        alertTitle={messages.loginFailureHeaderTitle}
+      />
       <SocialAuthProviders />
       <div className="text-center my-3 my-sm-4">
         {formatMessage(messages.loginFormHeading2)}

--- a/src/forms/login-popup/messages.js
+++ b/src/forms/login-popup/messages.js
@@ -127,13 +127,6 @@ const messages = defineMessages({
     defaultMessage: 'An error has occurred. Try refreshing the page, or check your internet connection.',
     description: 'Error message that appears when server responds with 500 error code',
   },
-  loginTpaAuthenticationFailure: {
-    id: 'login.tpa.authentication.failure',
-    defaultMessage: 'We are sorry, you are not authorized to access edX via this channel. '
-        + 'Please contact your learning administrator or manager in order to access edX.'
-        + '{lineBreak}{lineBreak}Error Details:{lineBreak}{errorMessage}',
-    description: 'Error message third party authentication pipeline fails',
-  },
   loginIncorrectCredentialsErrorBeforeAccountBlockedText: {
     id: 'login.incorrect.credentials.error.before.account.blocked.text',
     defaultMessage: 'click here to reset it.',

--- a/src/forms/login-popup/tests/LoginPopup.test.jsx
+++ b/src/forms/login-popup/tests/LoginPopup.test.jsx
@@ -197,7 +197,7 @@ describe('LoginForm Test', () => {
     const { container } = render(reduxWrapper(<IntlLoginForm />));
 
     expect(
-      container.querySelector('#login-failure-alert').textContent,
+      container.querySelector('#SSO-failure-alert').textContent,
     ).toContain('Third party authentication failed.');
   });
 

--- a/src/forms/registration-popup/components/RegistrationFailureAlert.jsx
+++ b/src/forms/registration-popup/components/RegistrationFailureAlert.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Alert } from '@openedx/paragon';
 import PropTypes from 'prop-types';
@@ -27,7 +26,7 @@ const RegistrationFailureMessage = (props) => {
     context, errorCode,
   } = props;
 
-  if (!errorCode) {
+  if (!errorCode || errorCode === TPA_AUTHENTICATION_FAILURE) {
     return null;
   }
 
@@ -38,16 +37,6 @@ const RegistrationFailureMessage = (props) => {
      break;
     case FORBIDDEN_REQUEST:
       errorMessage = formatMessage(messages.registrationRateLimitError);
-      break;
-    case TPA_AUTHENTICATION_FAILURE:
-      errorMessage = formatMessage(
-        messages.registrationTPAAuthenticationFailure,
-        {
-          platform_name: getConfig().SITE_NAME,
-          lineBreak: <br />,
-          errorMessage: context.errorMessage,
-        },
-      );
       break;
     case TPA_SESSION_EXPIRED:
       errorMessage = formatMessage(messages.registrationTPASessionExpired, { provider: context.provider });

--- a/src/forms/registration-popup/components/tests/RegistrationFailureAlert.test.jsx
+++ b/src/forms/registration-popup/components/tests/RegistrationFailureAlert.test.jsx
@@ -12,6 +12,7 @@ import configureStore from 'redux-mock-store';
 import {
   FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR, TPA_AUTHENTICATION_FAILURE, TPA_SESSION_EXPIRED,
 } from '../../../../data/constants';
+import SSOFailureAlert from '../../../common-components/SSOFailureAlert';
 import RegistrationPage from '../../index';
 import RegistrationFailureAlert from '../RegistrationFailureAlert';
 
@@ -22,6 +23,7 @@ jest.mock('@edx/frontend-platform/i18n', () => ({
 
 const IntlRegistrationPage = injectIntl(RegistrationPage);
 const IntlRegistrationFailure = injectIntl(RegistrationFailureAlert);
+const IntlSSOFailureAlert = injectIntl(SSOFailureAlert);
 const mockStore = configureStore();
 
 jest.mock('react-router-dom', () => {
@@ -178,7 +180,7 @@ describe('RegistrationFailure', () => {
         failureCount: 0,
       };
 
-      const { container } = render(reduxWrapper(<IntlRegistrationFailure {...props} />));
+      const { container } = render(reduxWrapper(<IntlSSOFailureAlert {...props} />));
 
       const alert = container.querySelector('div.alert');
       expect(alert.textContent).toContain(expectedMessageSubstring);

--- a/src/forms/registration-popup/index.jsx
+++ b/src/forms/registration-popup/index.jsx
@@ -21,6 +21,7 @@ import {
 } from '../../data/constants';
 import './index.scss';
 import AuthenticatedRedirection from '../common-components/AuthenticatedRedirection';
+import SSOFailureAlert from '../common-components/SSOFailureAlert';
 import ThirdPartyAuthAlert from '../common-components/ThirdPartyAuthAlert';
 import {
   EmailField,
@@ -165,6 +166,12 @@ const RegistrationForm = () => {
           {formatMessage(messages.registrationFormHeading1)}
         </h2>
         <hr className="separator my-3 my-sm-4" />
+
+        <SSOFailureAlert
+          errorCode={errorCode.type}
+          context={{ errorMessage: thirdPartyAuthErrorMessage }}
+        />
+
         {(autoSubmitRegForm && !errorCode.type) ? (
           <div className="my-6 text-center">
             <Spinner animation="border" variant="primary" id="tpa-spinner" />
@@ -182,11 +189,13 @@ const RegistrationForm = () => {
             <ThirdPartyAuthAlert
               currentProvider={currentProvider}
             />
+
             <RegistrationFailureAlert
               errorCode={errorCode.type}
               failureCount={errorCode.count}
               context={{ provider: currentProvider, errorMessage: thirdPartyAuthErrorMessage }}
             />
+
             <Form id="registration-form" name="registration-form" className="d-flex flex-column my-4">
               <EmailField
                 name="email"

--- a/src/forms/registration-popup/tests/RegistrationPopup.test.jsx
+++ b/src/forms/registration-popup/tests/RegistrationPopup.test.jsx
@@ -360,6 +360,6 @@ describe('RegistrationForm Test', () => {
 
     const { container } = render(reduxWrapper(<IntlRegistrationForm />));
 
-    expect(container.querySelector('#registration-failure-alert').textContent).toContain(errorMsg);
+    expect(container.querySelector('#SSO-failure-alert').textContent).toContain(errorMsg);
   });
 });


### PR DESCRIPTION
### Description

This PR addresses the scenario where any errors associated with the SSO pipeline should display their corresponding error messages above the SSO buttons.

#### JIRA

[VAN-1962](https://2u-internal.atlassian.net/browse/VAN-1962)

#### How Has This Been Tested?

Unit tests

#### Screenshots/sandbox (optional):

https://github.com/edx/frontend-component-authn-edx/assets/7627421/10af91a9-fc1b-4e92-be97-b8a2afe66de0


<img width="600" alt="Screenshot 2024-06-04 at 12 28 54 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/7627421/60bdbb92-42cd-411b-bd1e-f0eab6f7df95">
<img width="601" alt="Screenshot 2024-06-04 at 12 28 40 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/7627421/34c4d2ee-7a8f-4bdd-b9ed-1cd6f1703510">




#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
