### PR TITLE
feat: vulnerable password redirect to forget password popup

### DIFF
--- a/src/authn-component/index.jsx
+++ b/src/authn-component/index.jsx
@@ -29,6 +29,7 @@ import {
 } from '../forms';
 import EnterpriseSSO from '../forms/enterprise-sso-popup';
 import { getTpaHint, getTpaProvider } from '../forms/enterprise-sso-popup/data/utils';
+import { REQUIRE_PASSWORD_CHANGE } from '../forms/login-popup/data/constants';
 /**
  * Main component that conditionally renders a login or registration form inside a modal window.
  *
@@ -52,6 +53,7 @@ export const AuthnComponent = ({
   const providers = useSelector(state => state.commonData.thirdPartyAuthContext?.providers);
   const secondaryProviders = useSelector(state => state.commonData.thirdPartyAuthContext?.secondaryProviders);
   const thirdPartyAuthApiStatus = useSelector(state => state.commonData.thirdPartyAuthApiStatus);
+  const loginErrorCode = useSelector(state => state.login.loginError?.errorCode);
 
   const tpaHint = getTpaHint();
   const { provider: tpaProvider } = getTpaProvider(tpaHint, providers, secondaryProviders);
@@ -62,7 +64,12 @@ export const AuthnComponent = ({
       setHasCloseButton(false);
       setScreenSize('fullscreen');
     }
-  }, [currentForm]);
+    if (loginErrorCode === REQUIRE_PASSWORD_CHANGE
+      && currentForm === FORGOT_PASSWORD_FORM
+    ) {
+      setHasCloseButton(false);
+    }
+  }, [currentForm, loginErrorCode]);
 
   useEffect(() => {
     if (tpaProvider) {

--- a/src/forms/login-popup/data/constants.js
+++ b/src/forms/login-popup/data/constants.js
@@ -5,7 +5,8 @@ export const INCORRECT_EMAIL_PASSWORD = 'incorrect-email-or-password';
 export const ALLOWED_DOMAIN_LOGIN_ERROR = 'allowed-domain-login-error';
 export const NON_COMPLIANT_PASSWORD_EXCEPTION = 'NonCompliantPasswordException';
 export const TPA_AUTHENTICATION_FAILURE = 'tpa-authentication-failure';
-
+export const NUDGE_PASSWORD_CHANGE = 'nudge-password-change';
+export const REQUIRE_PASSWORD_CHANGE = 'require-password-change';
 // Account Activation Message
 export const ACCOUNT_ACTIVATION_MESSAGE = {
   INFO: 'info',

--- a/src/forms/login-popup/data/reducers.js
+++ b/src/forms/login-popup/data/reducers.js
@@ -47,10 +47,15 @@ export const loginSlice = createSlice({
       state.loginResult = {};
       state.submitState = FAILURE_STATE;
     },
+    loginErrorClear: (state) => {
+      state.loginError = {};
+      state.submitState = DEFAULT_STATE;
+    },
   },
 });
 
 export const {
+  loginErrorClear,
   loginUser,
   loginUserSuccess,
   loginUserFailed,

--- a/src/forms/login-popup/index.jsx
+++ b/src/forms/login-popup/index.jsx
@@ -9,6 +9,7 @@ import {
 
 import AccountActivationMessage from './components/AccountActivationMessage';
 import LoginFailureAlert from './components/LoginFailureAlert';
+import { NUDGE_PASSWORD_CHANGE, REQUIRE_PASSWORD_CHANGE } from './data/constants';
 import useGetActivationMessage from './data/hooks';
 import { loginUser } from './data/reducers';
 import messages from './messages';
@@ -76,8 +77,11 @@ const LoginForm = () => {
         type: loginErrorCode,
         context: { ...loginErrorContext },
       });
+      if (loginErrorCode === NUDGE_PASSWORD_CHANGE || loginErrorCode === REQUIRE_PASSWORD_CHANGE) {
+        dispatch(setCurrentOpenedForm(FORGOT_PASSWORD_FORM));
+      }
     }
-  }, [loginErrorCode, loginErrorContext]);
+  }, [dispatch, loginErrorCode, loginErrorContext]);
 
   useEffect(() => {
     if (thirdPartyAuthErrorMessage) {

--- a/src/forms/login-popup/tests/LoginPopup.test.jsx
+++ b/src/forms/login-popup/tests/LoginPopup.test.jsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_STATE, FORGOT_PASSWORD_FORM, INTERNAL_SERVER_ERROR, REGISTRATION_FORM,
 } from '../../../data/constants';
 import getAllPossibleQueryParams from '../../../data/utils';
+import { NUDGE_PASSWORD_CHANGE, REQUIRE_PASSWORD_CHANGE } from '../data/constants';
 import { loginUser } from '../data/reducers';
 import LoginForm from '../index';
 
@@ -52,6 +53,7 @@ describe('LoginForm Test', () => {
       loginError: {},
     },
     commonData: {
+      currentForm: '',
       thirdPartyAuthContext: {
         finishAuthUrl: null,
         providers: [],
@@ -66,6 +68,10 @@ describe('LoginForm Test', () => {
       AUTHN_TOS_AND_HONOR_CODE_LINK: process.env.AUTHN_TOS_AND_HONOR_CODE_LINK,
       AUTHN_PRIVACY_POLICY_LINK: process.env.AUTHN_PRIVACY_POLICY_LINK,
     });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should render login form', () => {
@@ -247,6 +253,40 @@ describe('LoginForm Test', () => {
     const { getByText } = render(reduxWrapper(<IntlLoginForm />));
 
     fireEvent.click(getByText('Forgot Password?'));
+
+    expect(store.dispatch).toHaveBeenCalledWith(setCurrentOpenedForm(FORGOT_PASSWORD_FORM));
+  });
+
+  it('should redirects to forget password popup if login API returns error code NUDGE_PASSWORD_CHANGE', () => {
+    store = mockStore({
+      ...initialState,
+      login: {
+        ...initialState.login,
+        loginError: {
+          errorCode: NUDGE_PASSWORD_CHANGE,
+        },
+      },
+    });
+    store.dispatch = jest.fn(store.dispatch);
+
+    render(reduxWrapper(<IntlLoginForm />));
+
+    expect(store.dispatch).toHaveBeenCalledWith(setCurrentOpenedForm(FORGOT_PASSWORD_FORM));
+  });
+
+  it('should redirects to forget password popup if login API returns error code REQUIRE_PASSWORD_CHANGE', () => {
+    store = mockStore({
+      ...initialState,
+      login: {
+        ...initialState.login,
+        loginError: {
+          errorCode: REQUIRE_PASSWORD_CHANGE,
+        },
+      },
+    });
+    store.dispatch = jest.fn(store.dispatch);
+
+    render(reduxWrapper(<IntlLoginForm />));
 
     expect(store.dispatch).toHaveBeenCalledWith(setCurrentOpenedForm(FORGOT_PASSWORD_FORM));
   });

--- a/src/forms/reset-password-popup/forgot-password/index.jsx
+++ b/src/forms/reset-password-popup/forgot-password/index.jsx
@@ -19,6 +19,8 @@ import {
   trackForgotPasswordPageEvent,
 } from '../../../tracking/trackers/forgotpassword';
 import EmailField from '../../fields/email-field';
+import { NUDGE_PASSWORD_CHANGE, REQUIRE_PASSWORD_CHANGE } from '../../login-popup/data/constants';
+import { loginErrorClear } from '../../login-popup/data/reducers';
 import messages from '../messages';
 import ResetPasswordHeader from '../ResetPasswordHeader';
 
@@ -33,6 +35,7 @@ const ForgotPasswordForm = () => {
   const dispatch = useDispatch();
 
   const status = useSelector(state => state.forgotPassword?.status);
+  const loginErrorCode = useSelector(state => state.login.loginError?.errorCode);
 
   const [formErrors, setFormErrors] = useState('');
   const [formFields, setFormFields] = useState({ email: '' });
@@ -52,6 +55,7 @@ const ForgotPasswordForm = () => {
   const backToLogin = (e) => {
     e.preventDefault();
     dispatch(forgotPasswordClearStatus());
+    dispatch(loginErrorClear());
     dispatch(setCurrentOpenedForm(LOGIN_FORM));
   };
 
@@ -78,6 +82,12 @@ const ForgotPasswordForm = () => {
     <Container size="lg" className="authn__popup-container overflow-auto">
       <ResetPasswordHeader />
       <ForgotPasswordFailureAlert emailError={formErrors} status={status} />
+      {loginErrorCode === REQUIRE_PASSWORD_CHANGE && (
+        <p data-testid="require-password-change-message">{formatMessage(messages.vulnerablePasswordBlockedMessage)}</p>
+      )}
+      {loginErrorCode === NUDGE_PASSWORD_CHANGE && (
+        <p data-testid="nudge-password-change-message">{formatMessage(messages.vulnerablePasswordWarnedMessage)}</p>
+      )}
       {!isSuccess && (
         <Form id="forgot-password-form" name="reset-password-form" className="d-flex flex-column">
           <EmailField
@@ -124,17 +134,19 @@ const ForgotPasswordForm = () => {
         <ForgotPasswordSuccess email={formFields.email} />
       )}
       <div className="text-center mt-4.5">
-        <Button
-          id="reset-password-back-to-login"
-          name="reset-password-back-to-login"
-          variant="tertiary"
-          type="submit"
-          className="align-self-center back-to-login__button"
-          onClick={backToLogin}
-          onMouseDown={(e) => e.preventDefault()}
-        >
-          {formatMessage(messages.resetPasswordBackToLoginButton)}
-        </Button>
+        {(loginErrorCode !== REQUIRE_PASSWORD_CHANGE) && (
+          <Button
+            id="reset-password-back-to-login"
+            name="reset-password-back-to-login"
+            variant="tertiary"
+            type="submit"
+            className="align-self-center back-to-login__button"
+            onClick={backToLogin}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            {formatMessage(messages.resetPasswordBackToLoginButton)}
+          </Button>
+        )}
       </div>
     </Container>
   );

--- a/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
+++ b/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
@@ -8,6 +8,8 @@ import configureStore from 'redux-mock-store';
 
 import { setCurrentOpenedForm } from '../../../../authn-component/data/reducers';
 import { COMPLETE_STATE, LOGIN_FORM } from '../../../../data/constants';
+import { NUDGE_PASSWORD_CHANGE, REQUIRE_PASSWORD_CHANGE } from '../../../login-popup/data/constants';
+import { loginErrorClear } from '../../../login-popup/data/reducers';
 import { forgotPassword, forgotPasswordClearStatus } from '../data/reducers';
 import ForgotPasswordPage from '../index';
 
@@ -20,6 +22,11 @@ const IntlForgotPasswordPage = injectIntl(ForgotPasswordPage);
 const mockStore = configureStore();
 
 const initialState = {
+  login: {
+    loginError: {
+      errorCode: '',
+    },
+  },
   forgotPassword: {
     status: '',
   },
@@ -89,6 +96,7 @@ describe('ForgotPasswordPage', () => {
     const actions = store.getActions();
     expect(actions).toEqual([
       { type: forgotPasswordClearStatus.type },
+      { type: loginErrorClear.type },
       { type: setCurrentOpenedForm.type, payload: LOGIN_FORM },
     ]);
   });
@@ -96,6 +104,7 @@ describe('ForgotPasswordPage', () => {
   it('handles COMPLETE_STATE correctly in useEffect', () => {
     // Update initial state to COMPLETE_STATE
     store = mockStore({
+      ...initialState,
       forgotPassword: {
         status: COMPLETE_STATE,
       },
@@ -154,5 +163,35 @@ describe('ForgotPasswordPage', () => {
     fireEvent(submitButton, mockMouseDownEvent);
 
     expect(mockMouseDownEvent.preventDefault).toHaveBeenCalled();
+  });
+
+  it('should show password vulnerability warned message copy if login errorCode is NUDGE_PASSWORD_CHANGE', () => {
+    store = mockStore({
+      ...initialState,
+      login: {
+        loginError: {
+          errorCode: NUDGE_PASSWORD_CHANGE,
+        },
+      },
+    });
+
+    const { getByTestId } = render(reduxWrapper(<IntlForgotPasswordPage />));
+
+    expect(getByTestId('nudge-password-change-message')).toBeTruthy();
+  });
+
+  it('should show password vulnerability blocked message copy if login errorCode is NUDGE_PASSWORD_CHANGE', () => {
+    store = mockStore({
+      ...initialState,
+      login: {
+        loginError: {
+          errorCode: REQUIRE_PASSWORD_CHANGE,
+        },
+      },
+    });
+
+    const { getByTestId } = render(reduxWrapper(<IntlForgotPasswordPage />));
+
+    expect(getByTestId('require-password-change-message')).toBeTruthy();
   });
 });

--- a/src/forms/reset-password-popup/messages.js
+++ b/src/forms/reset-password-popup/messages.js
@@ -51,6 +51,17 @@ const messages = defineMessages({
     defaultMessage: 'Enter and confirm the new password',
     description: 'Message for entering and confirming the new password',
   },
+  // vulnerable password messages
+  vulnerablePasswordBlockedMessage: {
+    id: 'vulnerable.blocked.password.message',
+    defaultMessage: 'Our system detected critical password vulnerability. Please reset your password to keep your account secure.',
+    description: 'Message for blocking user to reset password due to vulnerable password',
+  },
+  vulnerablePasswordWarnedMessage: {
+    id: 'vulnerable.warned.password.message',
+    defaultMessage: 'Our system detected password vulnerability. We encourage you to reset your password to keep your account secure.',
+    description: 'Message for warned user to reset password due to vulnerable password',
+  },
   // email sent messages
   emailSentMessage: {
     id: 'email.sent.message',


### PR DESCRIPTION

### Description

Redirect the user to forget password page if the user's password is vulnerable during the login experience.

#### JIRA

[VAN-1969](https://2u-internal.atlassian.net/browse/VAN-1969)

#### How Has This Been Tested?

Through unit tests and manual testing

#### Screenshots/sandbox (optional):

<table>
<tr>
<td>require-password-change</td>
<td>
<img width="816" alt="Screenshot 2024-06-04 at 2 14 31 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/78487564/d91af685-1060-4d79-a2bd-c8f358eac97d">
</td>
</tr>
<tr>
<td>nudge-password-change</td>
<td>
<img width="813" alt="Screenshot 2024-06-04 at 2 13 28 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/78487564/eafd4b87-b276-49cb-9228-fea2cdaab040">
</td>
</tr>
</table>

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
