### PR TITLE
fix: Update popup focus on forms

### DIFF
--- a/src/common-ui/SocialAuthButtons/index.jsx
+++ b/src/common-ui/SocialAuthButtons/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { useSelector } from 'react-redux';
 
 import { getConfig } from '@edx/frontend-platform';
@@ -23,7 +23,8 @@ import './index.scss';
  *
  * @returns {JSX.Element} The rendered SocialAuthButton component.
  */
-export const SocialAuthButton = ({ provider, isLoginForm, inverseTextColor }) => {
+export const SocialAuthButton = forwardRef((props, ref) => {
+  const { provider, isLoginForm, inverseTextColor } = props;
   const { formatMessage } = useIntl();
 
   if (!provider) {
@@ -46,6 +47,7 @@ export const SocialAuthButton = ({ provider, isLoginForm, inverseTextColor }) =>
 
   return (
     <Button
+      ref={ref}
       id={providerId}
       type="button"
       data-provider-url={isLoginForm ? loginUrl : registerUrl}
@@ -69,7 +71,7 @@ export const SocialAuthButton = ({ provider, isLoginForm, inverseTextColor }) =>
       </span>
     </Button>
   );
-};
+});
 
 SocialAuthButton.propTypes = {
   provider: PropTypes.shape({
@@ -94,7 +96,8 @@ SocialAuthButton.defaultProps = {
  *
  * @returns {JSX.Element} The rendered SocialAuthProviders component.
  */
-const SocialAuthProviders = ({ isLoginForm }) => {
+const SocialAuthProviders = forwardRef((props, ref) => {
+  const { isLoginForm } = props;
   const thirdPartyAuthApiStatus = useSelector(state => state.commonData.thirdPartyAuthApiStatus);
   const providers = useSelector(providersSelector);
 
@@ -105,13 +108,13 @@ const SocialAuthProviders = ({ isLoginForm }) => {
   }
   return (
     <div className="d-flex flex-column">
-      <SocialAuthButton isLoginForm={isLoginForm} provider={providers?.Google} />
+      <SocialAuthButton isLoginForm={isLoginForm} provider={providers?.Google} ref={ref} />
       <SocialAuthButton isLoginForm={isLoginForm} provider={providers?.Apple} inverseTextColor />
       <SocialAuthButton isLoginForm={isLoginForm} provider={providers?.Facebook} inverseTextColor />
       <SocialAuthButton isLoginForm={isLoginForm} provider={providers?.Microsoft} />
     </div>
   );
-};
+});
 
 SocialAuthProviders.propTypes = {
   isLoginForm: PropTypes.bool,

--- a/src/forms/common-components/SSOFailureAlert.jsx
+++ b/src/forms/common-components/SSOFailureAlert.jsx
@@ -36,7 +36,7 @@ const SSOFailureAlert = (props) => {
 
   return (
     <Alert id="SSO-failure-alert" className="mb-4" variant="danger">
-      {alertTitle && formatMessage(alertTitle)} {errorMessage}
+      {alertTitle && <span>{alertTitle}</span>} {errorMessage}
     </Alert>
   );
 };

--- a/src/forms/fields/email-field/index.jsx
+++ b/src/forms/fields/email-field/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -20,7 +20,7 @@ import './index.scss';
  * It is responsible for
  * - setting value on change
  */
-const EmailField = (props) => {
+const EmailField = forwardRef((props, ref) => {
   const dispatch = useDispatch();
 
   const { formatMessage } = useIntl();
@@ -111,6 +111,7 @@ const EmailField = (props) => {
         onBlur={handleOnBlur}
         onFocus={handleOnFocus}
         floatingLabel={floatingLabel}
+        ref={ref} // Forwarding the ref here
       />
 
       {errorMessage !== '' && (
@@ -121,7 +122,7 @@ const EmailField = (props) => {
       {emailSuggestion.suggestion && isRegistration ? renderEmailFeedback() : null}
     </Form.Group>
   );
-};
+});
 
 EmailField.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/forms/fields/password-field/index.jsx
+++ b/src/forms/fields/password-field/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { forwardRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -25,7 +25,7 @@ import './index.scss';
  * - setting value on change
  * - clearing the error state
  */
-const PasswordField = (props) => {
+const PasswordField = forwardRef((props, ref) => {
   const { formatMessage } = useIntl();
 
   const dispatch = useDispatch();
@@ -148,6 +148,7 @@ const PasswordField = (props) => {
     <Form.Group key={name} controlId="password" className="w-100 mb-4">
       <OverlayTrigger key="tooltip" placement={placement} overlay={tooltip} show={showPasswordRequirements}>
         <Form.Control
+          ref={ref}
           as="input"
           data-testid={dataTestId}
           className="mr-0"
@@ -206,7 +207,7 @@ const PasswordField = (props) => {
       )}
     </Form.Group>
   );
-};
+});
 
 PasswordField.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/forms/fields/text-field/index.jsx
+++ b/src/forms/fields/text-field/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
 import { Form } from '@openedx/paragon';
@@ -15,7 +15,7 @@ import './index.scss';
  * - setting value on change
  * - clearing error on focus
  */
-const TextField = (props) => {
+const TextField = forwardRef((props, ref) => {
   const { formatMessage } = useIntl();
   const {
     errorMessage,
@@ -41,6 +41,7 @@ const TextField = (props) => {
         onBlur={handleBlur}
         autoComplete={autoComplete}
         floatingLabel={formatMessage(messages.fieldLabel, { label })}
+        ref={ref}
       />
       {errorMessage !== '' && (
         <Form.Control.Feedback
@@ -55,7 +56,7 @@ const TextField = (props) => {
       )}
     </Form.Group>
   );
-};
+});
 
 TextField.propTypes = {
   errorMessage: PropTypes.string.isRequired,

--- a/src/forms/login-popup/index.jsx
+++ b/src/forms/login-popup/index.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
@@ -46,6 +48,9 @@ const LoginForm = () => {
   const dispatch = useDispatch();
   const queryParams = useMemo(() => getAllPossibleQueryParams(), []);
 
+  const emailOrUsernameRef = useRef(null);
+  const socialAuthnButtonRef = useRef(null);
+
   const loginResult = useSelector(state => state.login.loginResult);
   const loginErrorCode = useSelector(state => state.login.loginError?.errorCode);
   const loginErrorContext = useSelector(state => state.login.loginError?.errorContext);
@@ -71,6 +76,19 @@ const LoginForm = () => {
 
   useEffect(() => {
     trackLoginPageEvent();
+  }, []);
+
+  useEffect(() => {
+    const focusInterval = setInterval(() => {
+      if (socialAuthnButtonRef.current) {
+        socialAuthnButtonRef.current.focus();
+        clearInterval(focusInterval);
+      } else if (emailOrUsernameRef.current) {
+        emailOrUsernameRef.current.focus();
+      }
+    }, 100);
+
+    return () => clearInterval(focusInterval);
   }, []);
 
   useEffect(() => {
@@ -165,11 +183,11 @@ const LoginForm = () => {
       <SSOFailureAlert
         errorCode={errorCode.type}
         context={errorCode.context}
-        alertTitle={messages.loginFailureHeaderTitle}
+        alertTitle={formatMessage(messages.loginFailureHeaderTitle)}
       />
       {!currentProvider && (
         <>
-          <SocialAuthProviders />
+          <SocialAuthProviders ref={socialAuthnButtonRef} />
           <div className="text-center my-3 my-sm-4">
             {formatMessage(messages.loginFormHeading2)}
           </div>
@@ -195,6 +213,7 @@ const LoginForm = () => {
           errorMessage={formErrors.emailOrUsername}
           handleChange={handleOnChange}
           handleFocus={handleOnFocus}
+          ref={emailOrUsernameRef}
         />
         <PasswordField
           name="password"

--- a/src/forms/reset-password-popup/forgot-password/index.jsx
+++ b/src/forms/reset-password-popup/forgot-password/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { getConfig } from '@edx/frontend-platform';
@@ -23,7 +23,6 @@ import { NUDGE_PASSWORD_CHANGE, REQUIRE_PASSWORD_CHANGE } from '../../login-popu
 import { loginErrorClear } from '../../login-popup/data/reducers';
 import messages from '../messages';
 import ResetPasswordHeader from '../ResetPasswordHeader';
-
 import '../index.scss';
 
 /**
@@ -33,13 +32,15 @@ import '../index.scss';
 const ForgotPasswordForm = () => {
   const { formatMessage } = useIntl();
   const dispatch = useDispatch();
-
   const status = useSelector(state => state.forgotPassword?.status);
   const loginErrorCode = useSelector(state => state.login.loginError?.errorCode);
 
   const [formErrors, setFormErrors] = useState('');
   const [formFields, setFormFields] = useState({ email: '' });
   const [isSuccess, setIsSuccess] = useState(false);
+
+  const emailRef = useRef(null);
+  const errorRef = useRef(null);
 
   useEffect(() => {
     forgotPasswordPageViewedEvent();
@@ -66,6 +67,20 @@ const ForgotPasswordForm = () => {
     }
   }, [status]);
 
+  useEffect(() => {
+    if (emailRef.current) {
+      emailRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (formErrors && errorRef.current) {
+      setTimeout(() => {
+        errorRef.current.focus();
+      }, 100);
+    }
+  }, [formErrors]);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     setFormErrors('');
@@ -81,7 +96,9 @@ const ForgotPasswordForm = () => {
   return (
     <Container size="lg" className="authn__popup-container overflow-auto">
       <ResetPasswordHeader />
-      <ForgotPasswordFailureAlert emailError={formErrors} status={status} />
+      <div ref={errorRef} tabIndex="-1" aria-live="assertive">
+        <ForgotPasswordFailureAlert emailError={formErrors} status={status} />
+      </div>
       {loginErrorCode === REQUIRE_PASSWORD_CHANGE && (
         <p data-testid="require-password-change-message">{formatMessage(messages.vulnerablePasswordBlockedMessage)}</p>
       )}
@@ -98,6 +115,7 @@ const ForgotPasswordForm = () => {
             errorMessage={formErrors}
             floatingLabel={formatMessage(messages.forgotPasswordFormEmailFieldLabel)}
             isRegistration={false}
+            ref={emailRef}
           />
           <StatefulButton
             id="reset-password-user"

--- a/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
+++ b/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
@@ -94,11 +94,11 @@ describe('ForgotPasswordPage', () => {
     fireEvent.click(backToLoginButton);
 
     const actions = store.getActions();
-    expect(actions).toEqual([
+    expect(actions).toEqual(expect.arrayContaining([
       { type: forgotPasswordClearStatus.type },
       { type: loginErrorClear.type },
       { type: setCurrentOpenedForm.type, payload: LOGIN_FORM },
-    ]);
+    ]));
   });
 
   it('handles COMPLETE_STATE correctly in useEffect', () => {

--- a/src/forms/reset-password-popup/reset-password/index.jsx
+++ b/src/forms/reset-password-popup/reset-password/index.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { useIntl } from '@edx/frontend-platform/i18n';
@@ -43,6 +45,9 @@ const ResetPasswordPage = () => {
   const [formErrors, setFormErrors] = useState({});
   const [errorCode, setErrorCode] = useState(null);
 
+  const newPasswordRef = useRef(null);
+  const errorRef = useRef(null);
+
   const status = useSelector(state => state.resetPassword.status);
   const errorMsg = useSelector(state => state.resetPassword?.errorMsg);
   const backendValidationError = useSelector(state => state.resetPassword?.backendValidationError);
@@ -61,6 +66,20 @@ const ResetPasswordPage = () => {
       newPassword: backendValidationError || '',
     }));
   }, [backendValidationError]);
+
+  useEffect(() => {
+    if (newPasswordRef.current) {
+      newPasswordRef.current.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (formErrors && Object.keys(formErrors).length > 0 && errorRef.current) {
+      setTimeout(() => {
+        errorRef.current.focus();
+      }, 100);
+    }
+  }, [formErrors]);
 
   useEffect(() => {
     trackResettPasswordPageEvent();
@@ -149,7 +168,9 @@ const ResetPasswordPage = () => {
   return (
     <Container size="lg" className="authn__popup-container overflow-auto">
       <ResetPasswordHeader />
-      <ResetPasswordFailure errorCode={errorCode} errorMsg={errorMsg} />
+      <div ref={errorRef} tabIndex="-1" aria-live="assertive">
+        <ResetPasswordFailure errorCode={errorCode} errorMsg={errorMsg} />
+      </div>
       <div className="text-gray-800 mb-4">{formatMessage(messages.enterConfirmPasswordMessage)}</div>
       <Form id="set-reset-password-form" name="set-reset-password-form" className="d-flex flex-column">
         <PasswordField
@@ -162,6 +183,7 @@ const ResetPasswordPage = () => {
           handleBlur={handleOnBlur}
           errorMessage={formErrors.newPassword}
           floatingLabel={formatMessage(messages.newPasswordLabel)}
+          ref={newPasswordRef}
         />
         <PasswordField
           id="confirmPassword"


### PR DESCRIPTION
### Description

The PR addresses the following issues:
- When a login or register popup is opened, the focus should automatically go to the first SSO button.
- When the forgot password popup is opened, the focus should be on the "email" field.
- When the password reset popup is opened, the focus should be on the "new password" field.
- If there are no SSO buttons in the login or register form, the focus should be on the first field of the form.
- When an error occurs, the focus should move to the alert message.

#### JIRA

[VAn-1963](https://2u-internal.atlassian.net/browse/VAN-1963)

#### How Has This Been Tested?

Tested by Chrome screen reader extension

#### Screenshots/sandbox (optional):

https://github.com/edx/frontend-component-authn-edx/assets/7627421/780c86ef-0568-470f-8f3b-c9ea608b7cc6




#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
