### PR TITLE
fix: fix nudge password message copy on email sent success

### DIFF
--- a/src/forms/reset-password-popup/forgot-password/index.jsx
+++ b/src/forms/reset-password-popup/forgot-password/index.jsx
@@ -12,7 +12,7 @@ import ForgotPasswordFailureAlert from './ForgotPasswordFailureAlert';
 import ForgotPasswordSuccess from './ForgotPasswordSuccess';
 import { setCurrentOpenedForm } from '../../../authn-component/data/reducers';
 import { InlineLink } from '../../../common-ui';
-import { COMPLETE_STATE, LOGIN_FORM } from '../../../data/constants';
+import { COMPLETE_STATE, DEFAULT_STATE, LOGIN_FORM } from '../../../data/constants';
 import { useDispatch, useSelector } from '../../../data/storeHooks';
 import {
   forgotPasswordPageViewedEvent,
@@ -94,7 +94,7 @@ const ForgotPasswordForm = () => {
     <Container size="lg" className="authn__popup-container overflow-auto">
       <ResetPasswordHeader />
       <ForgotPasswordFailureAlert emailError={formErrors} status={status} />
-      {loginErrorCode === REQUIRE_PASSWORD_CHANGE && (
+      {status === DEFAULT_STATE && loginErrorCode === REQUIRE_PASSWORD_CHANGE && (
         <p
           aria-live="assertive"
           tabIndex="-1"
@@ -104,7 +104,7 @@ const ForgotPasswordForm = () => {
           {formatMessage(messages.vulnerablePasswordBlockedMessage)}
         </p>
       )}
-      {loginErrorCode === NUDGE_PASSWORD_CHANGE && (
+      {status === DEFAULT_STATE && loginErrorCode === NUDGE_PASSWORD_CHANGE && (
         <p
           tabIndex="-1"
           aria-live="assertive"

--- a/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
+++ b/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
@@ -7,7 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
 import { setCurrentOpenedForm } from '../../../../authn-component/data/reducers';
-import { COMPLETE_STATE, LOGIN_FORM } from '../../../../data/constants';
+import { COMPLETE_STATE, DEFAULT_STATE, LOGIN_FORM } from '../../../../data/constants';
 import { AuthnContext } from '../../../../data/storeHooks';
 import { NUDGE_PASSWORD_CHANGE, REQUIRE_PASSWORD_CHANGE } from '../../../login-popup/data/constants';
 import { loginErrorClear } from '../../../login-popup/data/reducers';
@@ -24,7 +24,7 @@ const initialState = {
     },
   },
   forgotPassword: {
-    status: '',
+    status: DEFAULT_STATE,
   },
 };
 
@@ -189,6 +189,9 @@ describe('ForgotPasswordPage', () => {
         loginError: {
           errorCode: REQUIRE_PASSWORD_CHANGE,
         },
+      },
+      forgotPassword: {
+        status: DEFAULT_STATE,
       },
     });
 


### PR DESCRIPTION
### Description

fix nudge password message copy on email sent success


#### How Has This Been Tested?

Through unit tests and manual testing
#### Screenshots/sandbox (optional):
[screen-capture (2).webm](https://github.com/edx/frontend-component-authn-edx/assets/78487564/32a35a23-bdfa-4872-92d2-c35521a28de9)

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
