### PR TITLE
fix: progressive profiling should be full height

### DIFF
--- a/src/base-container/index.jsx
+++ b/src/base-container/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ModalDialog } from '@openedx/paragon';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { deleteQueryParams } from '../data/utils';
@@ -37,7 +38,12 @@ const BaseContainer = ({
       isBlocking
       variant="default"
       title="authn-component"
-      className="bg-light-200 authn-component__modal"
+      className={classNames(
+        'bg-light-200 authn-component__modal',
+        {
+          'authn-component__modal-full-height': size === 'fullscreen',
+        },
+      )}
       hasCloseButton={hasCloseButton}
     >
       <ModalDialog.Body className="modal-body-container p-0">

--- a/src/base-container/index.scss
+++ b/src/base-container/index.scss
@@ -4,6 +4,10 @@
   max-height: 98vh !important;
 }
 
+.authn-component__modal-full-height {
+  max-height: 100vh !important;
+}
+
 @media (max-width: 375px) {
   .authn-component__modal {
     max-height: 100vh !important;


### PR DESCRIPTION
Description:



### Description

- Progressive profiling form should be full height

#### How Has This Been Tested?

 - it has been tested locally

#### Screenshots:


|After|
|-----|
|![image](https://github.com/edx/frontend-component-authn-edx/assets/12580995/72c040bb-7442-4186-b13b-9be60529b3ec)|

