### PR TITLE
fix: redirects on the login popup

### DIFF
--- a/src/forms/login-popup/index.jsx
+++ b/src/forms/login-popup/index.jsx
@@ -28,7 +28,7 @@ import {
 import { useDispatch, useSelector } from '../../data/storeHooks';
 import getAllPossibleQueryParams from '../../data/utils';
 import {
-  trackForgotPasswordLinkClick, trackInstitutionLoginLinkClick, trackLoginPageEvent,
+  trackForgotPasswordLinkClick, trackLoginPageEvent,
 } from '../../tracking/trackers/login';
 import AuthenticatedRedirection from '../common-components/AuthenticatedRedirection';
 import SSOFailureAlert from '../common-components/SSOFailureAlert';
@@ -264,7 +264,6 @@ const LoginForm = () => {
         />
         <InlineLink
           destination={getConfig().LMS_BASE_URL + ENTERPRISE_LOGIN_URL}
-          onClick={trackInstitutionLoginLinkClick}
           linkHelpText={formatMessage(messages.loginFormSchoolAndOrganizationHelpText)}
           linkText={formatMessage(messages.loginFormSchoolAndOrganizationLink)}
         />

--- a/src/tracking/trackers/login.js
+++ b/src/tracking/trackers/login.js
@@ -3,7 +3,6 @@ import { createEventTracker, createPageEventTracker } from '../../data/segment/u
 export const eventNames = {
   forgotPasswordLinkClicked: 'edx.bi.password-reset_form.toggled',
   loginPageViewed: 'edx.bi.login_page.viewed',
-  institutionLoginFormToggled: 'edx.bi.institution_login_form.toggled',
   loginAndRegistration: 'login_and_registration',
 };
 
@@ -26,16 +25,4 @@ export const trackLoginPageViewed = () => createEventTracker(
 // Tracks the login page event.
 export const trackLoginPageEvent = () => {
   createPageEventTracker(eventNames.loginAndRegistration, 'login')();
-};
-
-// Tracks the event of clicking the institution login link.
-export const trackInstitutionLoginLinkClick = () => {
-  createEventTracker(eventNames.institutionLoginFormToggled, {
-    category: categories.userEngagement,
-  })();
-
-  createEventTracker(eventNames.loginAndRegistration, {
-    category: categories.userEngagement,
-    page_name: 'login',
-  })();
 };

--- a/src/tracking/trackers/tests/login.test.jsx
+++ b/src/tracking/trackers/tests/login.test.jsx
@@ -3,7 +3,6 @@ import {
   categories,
   eventNames,
   trackForgotPasswordLinkClick,
-  trackInstitutionLoginLinkClick,
   trackLoginPageEvent,
   trackLoginPageViewed,
 } from '../login';
@@ -43,19 +42,6 @@ describe('Tracking Functions', () => {
     expect(createPageEventTracker).toHaveBeenCalledWith(
       eventNames.loginAndRegistration,
       'login',
-    );
-  });
-
-  it('trackInstitutionLoginLinkClick function', () => {
-    trackInstitutionLoginLinkClick();
-
-    expect(createEventTracker).toHaveBeenCalledWith(
-      eventNames.institutionLoginFormToggled,
-      { category: categories.userEngagement },
-    );
-    expect(createEventTracker).toHaveBeenCalledWith(
-      eventNames.loginAndRegistration,
-      { category: categories.userEngagement, page_name: 'login' },
     );
   });
 });


### PR DESCRIPTION
### Description

- Removed incorrect segment event added to the school and organization link
- This fixed the redirect issue as well

#### How Has This Been Tested?

Locally
