### PR TITLE
fix: password reset validation call on submit

### DIFF
--- a/src/forms/fields/email-field/index.jsx
+++ b/src/forms/fields/email-field/index.jsx
@@ -31,6 +31,7 @@ const EmailField = forwardRef((props, ref) => {
     floatingLabel,
     errorMessage = '',
     handleErrorChange = () => {},
+    validateEmailFromBackend = true,
   } = props;
 
   const validationApiRateLimited = useSelector(state => state.register?.validationApiRateLimited);
@@ -44,7 +45,7 @@ const EmailField = forwardRef((props, ref) => {
 
     if (fieldError) {
       handleErrorChange('email', fieldError);
-    } else if (!validationApiRateLimited) {
+    } else if (!validationApiRateLimited && validateEmailFromBackend) {
       dispatch(fetchRealtimeValidations({ email: fieldValue }));
     }
   };
@@ -136,6 +137,7 @@ EmailField.propTypes = {
   floatingLabel: PropTypes.string.isRequired,
   errorMessage: PropTypes.string,
   isRegistration: PropTypes.bool,
+  validateEmailFromBackend: PropTypes.bool,
 };
 
 export default EmailField;

--- a/src/forms/reset-password-popup/forgot-password/index.jsx
+++ b/src/forms/reset-password-popup/forgot-password/index.jsx
@@ -123,6 +123,7 @@ const ForgotPasswordForm = () => {
             errorMessage={formErrors}
             floatingLabel={formatMessage(messages.forgotPasswordFormEmailFieldLabel)}
             isRegistration={false}
+            validateEmailFromBackend={false}
             ref={emailRef}
           />
           <StatefulButton

--- a/src/forms/reset-password-popup/reset-password/index.jsx
+++ b/src/forms/reset-password-popup/reset-password/index.jsx
@@ -51,7 +51,7 @@ const ResetPasswordPage = () => {
   const errorMsg = useSelector(state => state.resetPassword?.errorMsg);
   const backendValidationError = useSelector(state => state.resetPassword?.backendValidationError);
 
-  const validatePasswordFromBackend = async (password) => {
+  const validatePasswordFromBackend = (password) => {
     const payload = {
       reset_password_page: true,
       password,
@@ -82,14 +82,14 @@ const ResetPasswordPage = () => {
     trackResettPasswordPageEvent();
   }, []);
 
-  const validateInput = (name, value) => {
+  const validateInput = (name, value, shouldValidateFromBackend = true) => {
     switch (name) {
       case 'newPassword':
        if (!value) {
          formErrors.newPassword = formatMessage(messages.passwordRequiredMessage);
        } else if (!LETTER_REGEX.test(value) || !NUMBER_REGEX.test(value) || value.length < 8) {
          formErrors.newPassword = formatMessage(messages.passwordValidationMessage);
-       } else {
+       } else if (shouldValidateFromBackend) {
          validatePasswordFromBackend(value);
        }
         break;
@@ -130,7 +130,7 @@ const ResetPasswordPage = () => {
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    const isPasswordValid = validateInput('newPassword', newPassword);
+    const isPasswordValid = validateInput('newPassword', newPassword, false);
     const isPasswordConfirmed = validateInput('confirmPassword', confirmPassword);
     if (isPasswordValid && isPasswordConfirmed) {
       const formPayload = {


### PR DESCRIPTION
### Description

First password field on password reset form was being validated on both blur and form submit.

This PR fixes that by removing validation call from submit click

#### JIRA

[VAN-1971](https://2u-internal.atlassian.net/browse/VAN-1971)

#### How Has This Been Tested?

Locally

#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
