### PR TITLE
fix: password reset success message typo

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -14,6 +14,7 @@ AUTHN_ALGOLIA_APP_ID=''
 AUTHN_ALGOLIA_SEARCH_API_KEY=''
 # ***** Links *****
 TOS_AND_HONOR_CODE='http://localhost:18000/honor'
+PASSWORD_RESET_SUPPORT_LINK=''
 PRIVACY_POLICY='http://localhost:18000/privacy'
 LOGIN_ISSUE_SUPPORT_LINK='http://localhost:18000/login-issue-support-url'
 # ***** Cookies *****

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -26,6 +26,7 @@ initialize({
         AUTHN_ALGOLIA_APP_ID: process.env.AUTHN_ALGOLIA_APP_ID || '',
         AUTHN_ALGOLIA_SEARCH_API_KEY: process.env.AUTHN_ALGOLIA_SEARCH_API_KEY || '',
         TOS_AND_HONOR_CODE: process.env.TOS_AND_HONOR_CODE || '',
+        PASSWORD_RESET_SUPPORT_LINK: process.env.PASSWORD_RESET_SUPPORT_LINK || '',
         PRIVACY_POLICY: process.env.PRIVACY_POLICY || '',
         INFO_EMAIL: process.env.INFO_EMAIL || '',
         USER_RETENTION_COOKIE_NAME: process.env.USER_RETENTION_COOKIE_NAME || '',

--- a/src/forms/reset-password-popup/forgot-password/ForgotPasswordSuccess.jsx
+++ b/src/forms/reset-password-popup/forgot-password/ForgotPasswordSuccess.jsx
@@ -29,13 +29,13 @@ const ForgotPasswordSuccess = (props) => {
           defaultMessage="We sent an email to {email} with instructions to reset your password.
           If you do not receive a password reset message after 1 minute, verify that you entered
           the correct email address, or check your spam folder. If you need further assistance,
-          visit Help Center contact edX support at {supportLink}."
+          visit {helpCenter}."
           description="Forgot password confirmation message"
           values={{
             email: <span className="data-hj-suppress">{email}</span>,
-            supportLink: (
-              <Alert.Link href={getConfig().INFO_EMAIL} target="_blank">
-                {getConfig().INFO_EMAIL}
+            helpCenter: (
+              <Alert.Link href={getConfig().PASSWORD_RESET_SUPPORT_LINK} target="_blank">
+                {formatMessage(messages.helpCenter)}
               </Alert.Link>
             ),
           }}

--- a/src/forms/reset-password-popup/forgot-password/tests/ForgotPasswordSuccess.test.jsx
+++ b/src/forms/reset-password-popup/forgot-password/tests/ForgotPasswordSuccess.test.jsx
@@ -28,7 +28,7 @@ describe('ForgotPasswordFailureAlert Component', () => {
     + 'with instructions to reset your password. If you do not receive a password reset '
     + 'message after 1 minute, verify that you entered the correct email address, or '
     + 'check your spam folder. If you need further assistance, '
-    + 'visit Help Center contact edX support at info@edx.org.';
+    + 'visit Help Center.';
     expect(container.querySelector('#forgot-password-success-msg').textContent).toBe(expectedMessage);
   });
 });

--- a/src/forms/reset-password-popup/messages.js
+++ b/src/forms/reset-password-popup/messages.js
@@ -68,6 +68,11 @@ const messages = defineMessages({
     defaultMessage: 'Email has been sent',
     description: 'Notification message indicating that an email has been sent',
   },
+  helpCenter: {
+    id: 'help.center',
+    defaultMessage: 'Help Center',
+    description: 'Part of reset password success message.',
+  },
   // validation errors
   passwordRequiredMessage: {
     id: 'password.required.message',


### PR DESCRIPTION
### Description

- Fixed typo in the reset password success message
- The work is based on feedback provided by Alena

#### JIRA

N/A

#### How Has This Been Tested?

Updated unit test

#### Screenshots/sandbox (optional):

|Before (Figma SS)|After|
|-------|-----|
|<img width="749" alt="Screenshot 2024-06-24 at 4 58 42 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/40633976/6d0417cb-46a0-4cea-b685-be10917f50dd">|<img width="799" alt="Screenshot 2024-06-24 at 4 58 17 PM" src="https://github.com/edx/frontend-component-authn-edx/assets/40633976/3df0d5ab-bf06-48cb-ba29-97afb098ae9b">



#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
