### PR TITLE
fix: fix logging warnings to resolve accounts API issue on prospectus

### DIFF
--- a/src/forms/progressive-profiling-popup/index.jsx
+++ b/src/forms/progressive-profiling-popup/index.jsx
@@ -7,6 +7,7 @@ import {
   configure as configureAuth,
 } from '@edx/frontend-platform/auth';
 import { getCountryList, getLocale, useIntl } from '@edx/frontend-platform/i18n';
+import { getLoggingService } from '@edx/frontend-platform/logging';
 import {
   Container, Form, Icon, StatefulButton,
 } from '@openedx/paragon';
@@ -79,7 +80,7 @@ const ProgressiveProfilingForm = () => {
     }
     if (authenticatedUser?.userId) {
       identifyAuthenticatedUser(authenticatedUser?.userId);
-      configureAuth(AxiosJwtAuthService, { config: getConfig() });
+      configureAuth(AxiosJwtAuthService, { loggingService: getLoggingService(), config: getConfig() });
       trackProgressiveProfilingPageViewed();
     }
   }, [authenticatedUser, dispatch]);

--- a/src/forms/progressive-profiling-popup/index.test.jsx
+++ b/src/forms/progressive-profiling-popup/index.test.jsx
@@ -25,6 +25,10 @@ jest.mock('@edx/frontend-platform/auth', () => ({
   getAuthenticatedUser: jest.fn({}),
 }));
 
+jest.mock('@edx/frontend-platform/logging', () => ({
+  getLoggingService: jest.fn(),
+}));
+
 getAuthenticatedUser.mockReturnValue({ userId: 3, username: 'abc123', name: 'Test User' });
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),


### PR DESCRIPTION
### Description

On progressive profiling an accounts API is not triggering, to fix this issue we resolved logging warnings by initializing `AxiosJwtAuthService`  with `getLoggingService`