### PR TITLE
fix: fix error alert focus on login and registration form

### DIFF
--- a/src/forms/login-popup/index.jsx
+++ b/src/forms/login-popup/index.jsx
@@ -128,6 +128,9 @@ const LoginForm = () => {
       if (loginErrorCode === NUDGE_PASSWORD_CHANGE || loginErrorCode === REQUIRE_PASSWORD_CHANGE) {
         dispatch(setCurrentOpenedForm(FORGOT_PASSWORD_FORM));
       }
+      if (errorAlertRef.current) {
+        errorAlertRef.current.focus();
+      }
     }
   }, [dispatch, loginErrorCode, loginErrorContext]);
 
@@ -234,7 +237,7 @@ const LoginForm = () => {
           </div>
         </>
       )}
-      <div ref={errorAlertRef}>
+      <div ref={errorAlertRef} tabIndex="-1" aria-live="assertive">
         <LoginFailureAlert
           errorCode={errorCode.type}
           context={errorCode.context}

--- a/src/forms/registration-popup/index.jsx
+++ b/src/forms/registration-popup/index.jsx
@@ -203,6 +203,9 @@ const RegistrationForm = () => {
     if (registrationErrorCode) {
       setErrorCode(prevState => ({ type: registrationErrorCode, count: prevState.count + 1 }));
       moveScrollToTop(registerErrorAlertRef);
+      if (registerErrorAlertRef.current) {
+        registerErrorAlertRef.current.focus();
+      }
     }
   }, [registrationErrorCode]);
 
@@ -312,7 +315,7 @@ const RegistrationForm = () => {
               currentProvider={currentProvider}
               referrer={REGISTRATION_FORM}
             />
-            <div ref={registerErrorAlertRef}>
+            <div ref={registerErrorAlertRef} tabIndex="-1" aria-live="assertive">
               <RegistrationFailureAlert
                 errorCode={errorCode.type}
                 failureCount={errorCode.count}


### PR DESCRIPTION
### Description

In this PR, we fix the issue where the focus goes to the error alert on login and registration failure. Now, the screen reader reads the alert error message.

#### JIRA

[VAN-1990](https://2u-internal.atlassian.net/browse/VAN-1990)

#### How Has This Been Tested?

Locally

#### Screenshots/Videos :



https://github.com/edx/frontend-component-authn-edx/assets/7627421/c524ff9f-6ac9-49c7-b390-8e28912c85d3




#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
