### PR TITLE
fix: fix login nudge issue

### DIFF
--- a/src/base-container/index.jsx
+++ b/src/base-container/index.jsx
@@ -4,8 +4,10 @@ import { ModalDialog } from '@openedx/paragon';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import { useDispatch } from '../data/storeHooks';
+import { FORGOT_PASSWORD_FORM } from '../data/constants';
+import { useDispatch, useSelector } from '../data/storeHooks';
 import { deleteQueryParams } from '../data/utils';
+import { NUDGE_PASSWORD_CHANGE } from '../forms/login-popup/data/constants';
 import { loginErrorClear } from '../forms/login-popup/data/reducers';
 import { clearAllRegistrationErrors } from '../forms/registration-popup/data/reducers';
 import { forgotPasswordClearStatus } from '../forms/reset-password-popup/forgot-password/data/reducers';
@@ -28,10 +30,19 @@ const BaseContainer = ({
   hasCloseButton = true,
   isOpen,
   size = 'lg',
+  currentForm,
 }) => {
   const dispatch = useDispatch();
 
+  const loginErrorResult = useSelector(state => state.login.loginError);
+  const loginErrorCode = useSelector(state => state.login.loginError?.errorCode);
+
   const handleOnClose = () => {
+    if (loginErrorCode === NUDGE_PASSWORD_CHANGE
+      && loginErrorResult.redirectUrl
+      && currentForm === FORGOT_PASSWORD_FORM) {
+      window.location.href = loginErrorResult.redirectUrl;
+    }
     deleteQueryParams(['authMode', 'tpa_hint', 'password_reset_token', 'track']);
     dispatch(forgotPasswordClearStatus());
     dispatch(loginErrorClear());
@@ -70,6 +81,7 @@ BaseContainer.propTypes = {
   close: PropTypes.func.isRequired,
   size: PropTypes.string,
   hasCloseButton: PropTypes.bool,
+  currentForm: PropTypes.string.isRequired,
 };
 
 export default BaseContainer;

--- a/src/forms/login-popup/data/reducers.js
+++ b/src/forms/login-popup/data/reducers.js
@@ -53,10 +53,11 @@ export const loginSlice = createSlice({
         errorCode,
         email,
         value,
+        redirectUrl,
       } = payload;
 
       const errorContext = { ...context, email, errorMessage: value };
-      state.loginError = { errorCode, errorContext };
+      state.loginError = { errorCode, errorContext, redirectUrl };
       state.loginResult = {};
       state.submitState = FAILURE_STATE;
     },

--- a/src/forms/reset-password-popup/forgot-password/index.jsx
+++ b/src/forms/reset-password-popup/forgot-password/index.jsx
@@ -168,7 +168,8 @@ const ForgotPasswordForm = () => {
         <ForgotPasswordSuccess email={formFields.email} />
       )}
       <div className="text-center mt-4.5">
-        {loginErrorCode !== REQUIRE_PASSWORD_CHANGE && (
+        {loginErrorCode !== REQUIRE_PASSWORD_CHANGE
+        && loginErrorCode !== NUDGE_PASSWORD_CHANGE && (
           <Button
             id="reset-password-back-to-login"
             name="reset-password-back-to-login"

--- a/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
+++ b/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
@@ -34,6 +34,10 @@ const initialState = {
   },
 };
 
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedUser: jest.fn(),
+}));
+
 describe('ForgotPasswordPage', () => {
   let store = {};
 

--- a/src/onboarding-component/index.jsx
+++ b/src/onboarding-component/index.jsx
@@ -141,6 +141,7 @@ export const OnBoardingComponent = ({
       close={close}
       hasCloseButton={hasCloseButton}
       size={screenSize}
+      currentForm={currentForm}
     >
       {pendingState
         ? getSpinner()


### PR DESCRIPTION
### Description

- Hide “Back to login button on forgot password when password nudge case occurs 
- Redirect to finish auth URL when user click on cross button on forgot password form

#### JIRA

[VAN-2008](https://2u-internal.atlassian.net/browse/VAN-2008)

#### How Has This Been Tested?

- It has been tested locally 

### Screenshot

| Before  | After |
| ------------- | ------------- |
| https://github.com/user-attachments/assets/bdd14c97-6fc9-495f-98f5-ec1ea2bca834|https://github.com/user-attachments/assets/3c977ab8-0ce2-407a-9c97-22f080d0a31a|

