### PR TITLE
fix: update country msg on skip button

### DIFF
--- a/src/forms/progressive-profiling-popup/index.test.jsx
+++ b/src/forms/progressive-profiling-popup/index.test.jsx
@@ -320,4 +320,24 @@ describe('ProgressiveProfilingForm Test', () => {
 
     expect(window.location.href).not.toEqual('http://example.com');
   });
+
+  it('should display blocking error message and not redirect if country field is not set', async () => {
+    const { container, getByText } = render(reduxWrapper(<IntlProgressiveProfilingForm />));
+
+    // Ensure the form is initially rendered
+    expect(screen.getByTestId('progressive-profiling-heading')).toBeTruthy();
+    const countryInput = container.querySelector('#country');
+    fireEvent.click(countryInput);
+    const countryDropdownItem = container.querySelector('.dropdown-item');
+    fireEvent.click(countryDropdownItem);
+
+    const skipButton = container.querySelector('#skip-optional-fields');
+    jest.useFakeTimers();
+    await act(async () => {
+      fireEvent.click(skipButton);
+      jest.runAllTimers();
+    });
+
+    expect(getByText('Please click "Submit" to save changes in "Country of residence" field.')).toBeTruthy();
+  });
 });

--- a/src/forms/progressive-profiling-popup/messages.js
+++ b/src/forms/progressive-profiling-popup/messages.js
@@ -36,10 +36,9 @@ const messages = defineMessages({
     defaultMessage: 'Select a valid option',
     description: 'Error text appers on the country field when country is not selected and the user submit the form',
   },
-  // TODO update error message copy here when design team will provide it
   progressiveProfilingCountryFieldBlockingErrorMessage: {
     id: 'progressive.profiling.country.field.error.message',
-    defaultMessage: 'To proceed, please save your country of residence',
+    defaultMessage: 'Please click "Submit" to save changes in "Country of residence" field.',
     description: 'Error msg for country field when the user country is not detected on registration step and user want to skip progressive profiling form',
   },
   progressiveProfilingDataCollectionTitle: {


### PR DESCRIPTION
### Description

Update the country message when the user clicks the skip button, provided the user has a country value.

#### JIRA

[VAN-2009](https://2u-internal.atlassian.net/browse/VAn-2009)



#### Screenshots:

|Before|After|
|-------|-----|
|   <img width="923" alt="Screenshot 2024-07-19 at 2 36 19 PM" src="https://github.com/user-attachments/assets/9b8f2fe2-563e-4774-a6e9-7124ce2e1888">   |    <img width="935" alt="Screenshot 2024-07-19 at 2 36 53 PM" src="https://github.com/user-attachments/assets/71be2ae3-fddd-4f72-9614-9fe3eac519b6">  |



#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
