### PR TITLE
fix: user id not passing in registration success event

### DIFF
--- a/src/forms/progressive-profiling-popup/index.jsx
+++ b/src/forms/progressive-profiling-popup/index.jsx
@@ -3,7 +3,6 @@ import React, {
 } from 'react';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
-import { identifyAuthenticatedUser } from '@edx/frontend-platform/analytics';
 import {
   AxiosJwtAuthService,
   configure as configureAuth,
@@ -90,7 +89,6 @@ const ProgressiveProfilingForm = () => {
       dispatch(setCurrentOpenedForm(LOGIN_FORM));
     }
     if (authenticatedUser?.userId) {
-      identifyAuthenticatedUser(authenticatedUser?.userId);
       configureAuth(AxiosJwtAuthService, { loggingService: getLoggingService(), config: getConfig() });
       trackProgressiveProfilingPageViewed();
     }

--- a/src/forms/progressive-profiling-popup/index.test.jsx
+++ b/src/forms/progressive-profiling-popup/index.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import { getConfig } from '@edx/frontend-platform';
-import { identifyAuthenticatedUser } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { getLocale, injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { fireEvent, render, screen } from '@testing-library/react';
@@ -82,13 +81,6 @@ describe('ProgressiveProfilingForm Test', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('should make identify call to segment on progressive profiling page', () => {
-    render(reduxWrapper(<IntlProgressiveProfilingForm />));
-
-    expect(identifyAuthenticatedUser).toHaveBeenCalledWith(1);
-    expect(identifyAuthenticatedUser).toHaveBeenCalled();
   });
 
   it('should render progressive profiling form', () => {

--- a/src/forms/registration-popup/index.jsx
+++ b/src/forms/registration-popup/index.jsx
@@ -3,6 +3,7 @@ import React, {
 } from 'react';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
+import { identifyAuthenticatedUser } from '@edx/frontend-platform/analytics';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   breakpoints, Container, Form, Spinner, StatefulButton, useMediaQuery,
@@ -183,6 +184,8 @@ const RegistrationForm = () => {
 
   useEffect(() => {
     if (registrationResult.success) {
+      identifyAuthenticatedUser(registrationResult?.authenticatedUser?.userId);
+
       removeCookie('ssoPipelineRedirectionDone');
       removeCookie('marketingEmailsOptIn');
 

--- a/src/forms/registration-popup/tests/RegistrationPopup.test.jsx
+++ b/src/forms/registration-popup/tests/RegistrationPopup.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import { getConfig, mergeConfig } from '@edx/frontend-platform';
+import { identifyAuthenticatedUser } from '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
@@ -456,5 +457,26 @@ describe('RegistrationForm Test', () => {
 
     render(reduxWrapper(<IntlRegistrationForm />));
     expect(document.cookie).toMatch(`${getConfig().USER_RETENTION_COOKIE_NAME}=true`);
+  });
+
+  it('should make identify call to segment on registration success', () => {
+    store = mockStore({
+      ...initialState,
+      register: {
+        ...initialState.register,
+        registrationResult: {
+          success: true,
+          authenticatedUser: {
+            username: 'john_doe',
+            userId: 1,
+          },
+        },
+      },
+    });
+
+    render(reduxWrapper(<IntlRegistrationForm />));
+
+    expect(identifyAuthenticatedUser).toHaveBeenCalledWith(1);
+    expect(identifyAuthenticatedUser).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Description

User ID was not being passed in the registration success event so this PR makes an identify call before firing the registration success event so that the success event can have the user id.

#### JIRA

[VAN-2018](https://2u-internal.atlassian.net/browse/VAN-2018)

#### How Has This Been Tested?

Mention any tests you've added or updated to ensure the changes work as expected.

#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
