### PR TITLE
fix: fix segment event on reset password modal

### DIFF
--- a/src/forms/reset-password-popup/reset-password/index.jsx
+++ b/src/forms/reset-password-popup/reset-password/index.jsx
@@ -14,7 +14,6 @@ import {
 } from './data/constants';
 import { resetPassword, validatePassword, validateToken } from './data/reducers';
 import {
-  COMPLETE_STATE,
   DEFAULT_STATE, FORGOT_PASSWORD_FORM, FORM_SUBMISSION_ERROR, LOGIN_FORM, PENDING_STATE,
 } from '../../../data/constants';
 import { useDispatch, useSelector } from '../../../data/storeHooks';
@@ -49,7 +48,6 @@ const ResetPasswordPage = () => {
   const newPasswordRef = useRef(null);
 
   const status = useSelector(state => state.resetPassword.status);
-  const tokenValidationState = useSelector(state => state.resetPassword.status);
   const errorMsg = useSelector(state => state.resetPassword?.errorMsg);
   const backendValidationError = useSelector(state => state.resetPassword?.backendValidationError);
 
@@ -81,10 +79,10 @@ const ResetPasswordPage = () => {
   }, [status]);
 
   useEffect(() => {
-    if (tokenValidationState === COMPLETE_STATE && status === TOKEN_STATE.VALID) {
+    if (status === TOKEN_STATE.VALID) {
       trackResetPasswordPageViewed();
     }
-  }, [status, tokenValidationState]);
+  }, [status]);
 
   const validateInput = (name, value, shouldValidateFromBackend = true) => {
     switch (name) {

--- a/src/tracking/trackers/login.js
+++ b/src/tracking/trackers/login.js
@@ -22,7 +22,7 @@ export const trackLoginPageViewed = () => {
   createPageEventTracker(eventNames.loginAndRegistration, 'login')();
 };
 
-// Tracks the progressive profiling page event.
+// Tracks the event when the register link is clicked on the login form.
 export const trackRegisterFormToggled = () => {
   createEventTracker(
     eventNames.registerFormToggled,
@@ -30,7 +30,7 @@ export const trackRegisterFormToggled = () => {
   )();
 };
 
-// Tracks the login sucess event.
+// Tracks the login success event.
 export const trackLoginSuccess = () => createEventTracker(
   eventNames.loginSuccess,
   {},

--- a/src/tracking/trackers/register.js
+++ b/src/tracking/trackers/register.js
@@ -16,12 +16,12 @@ export const trackRegistrationSuccess = () => createEventTracker(
   {},
 )();
 
-// Tracks the progressive profiling page event.
+// Tracks the register page event.
 export const trackRegistrationPageViewed = () => {
   createPageEventTracker(eventNames.loginAndRegistration, 'register')();
 };
 
-// Tracks the progressive profiling page event.
+// Tracks the event when the login link is clicked on the register form..
 export const trackLoginFormToggled = () => {
   createEventTracker(
     eventNames.loginFormToggled,


### PR DESCRIPTION
### Description

- In this PR, I fixed the issue where the page view event was not being fired when the reset password modal was opened.

#### JIRA

[VAN-2032](https://2u-internal.atlassian.net/browse/VAN-2032)

#### How Has This Been Tested?

Mention any tests you've added or updated to ensure the changes work as expected.

#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if it's not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?
