### PR TITLE
fix: add query param for forgot password form

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -34,7 +34,8 @@ export const VALID_AUTH_PARAMS = [
 
 export const AUTH_MODE = 'authMode';
 export const AUTH_MODE_LOGIN = 'Login';
-export const AUTH_MODE_REGSITER = 'Register';
+export const AUTH_MODE_REGISTER = 'Register';
+export const AUTH_MODE_RESET_PASSWORD = 'ResetPassword';
 
 // Regular expression for validating email addresses.
 export const VALID_EMAIL_REGEX = '(^[-!#$%&\'*+/=?^_`{}|~0-9A-Z]+(\\.[-!#$%&\'*+/=?^_`{}|~0-9A-Z]+)*'

--- a/src/forms/registration-popup/index.jsx
+++ b/src/forms/registration-popup/index.jsx
@@ -24,7 +24,7 @@ import isFormValid from './data/utils';
 import messages from './messages';
 import { InlineLink, SocialAuthProviders } from '../../common-ui';
 import {
-  AUTH_MODE_REGSITER,
+  AUTH_MODE_REGISTER,
   COMPLETE_STATE,
   ENTERPRISE_LOGIN_URL,
   FAILURE_STATE,
@@ -148,7 +148,7 @@ const RegistrationForm = () => {
 
   useEffect(() => {
     moveScrollToTop(registerFormHeadingRef, 'end');
-    handleURLUpdationOnLoad(AUTH_MODE_REGSITER);
+    handleURLUpdationOnLoad(AUTH_MODE_REGISTER);
   }, []);
 
   useEffect(() => {

--- a/src/forms/reset-password-popup/forgot-password/index.jsx
+++ b/src/forms/reset-password-popup/forgot-password/index.jsx
@@ -11,8 +11,11 @@ import getValidationMessage from './data/utils';
 import ForgotPasswordFailureAlert from './ForgotPasswordFailureAlert';
 import ForgotPasswordSuccess from './ForgotPasswordSuccess';
 import { InlineLink } from '../../../common-ui';
-import { COMPLETE_STATE, DEFAULT_STATE, LOGIN_FORM } from '../../../data/constants';
+import {
+  AUTH_MODE_RESET_PASSWORD, COMPLETE_STATE, DEFAULT_STATE, LOGIN_FORM,
+} from '../../../data/constants';
 import { useDispatch, useSelector } from '../../../data/storeHooks';
+import { handleURLUpdationOnLoad } from '../../../data/utils';
 import { setCurrentOpenedForm } from '../../../onboarding-component/data/reducers';
 import { trackForgotPasswordPageEvent, trackForgotPasswordPageViewed } from '../../../tracking/trackers/forgotpassword';
 import EmailField from '../../fields/email-field';
@@ -57,6 +60,10 @@ const ForgotPasswordForm = () => {
       error: formErrors,
     }));
   };
+  useEffect(() => {
+    handleURLUpdationOnLoad(AUTH_MODE_RESET_PASSWORD);
+  }, []);
+
   const backToLogin = (e) => {
     e.preventDefault();
     backupFormDataHandler();

--- a/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
+++ b/src/forms/reset-password-popup/forgot-password/tests/index.test.jsx
@@ -51,6 +51,7 @@ describe('ForgotPasswordPage', () => {
 
   beforeEach(() => {
     store = mockStore(initialState);
+    window.history.replaceState = jest.fn();
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Description

This PR fixes the issue where, when the user clicks on the Forgot Password link, the URL should change to                            
 `?authMode=ResetPassword.`

#### JIRA

[VAN-2047](https://2u-internal.atlassian.net/browse/VAN-2047)

#### How Has This Been Tested?

Tested through unit tests and updated the tests

#### Screenshots/Video:

https://github.com/user-attachments/assets/4ed2ae48-3a42-4fea-915b-0af9257201cc




